### PR TITLE
Add Reflection Fallback and minor bug fix

### DIFF
--- a/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -28,6 +28,7 @@ import java.util.function.BiFunction;
  * @since 1.0
  */
 public class AnvilGUI {
+    private static final String GITHUB_LINK = "https://github.com/WesJD/AnvilGUI";
 
     /**
      * The player who has the GUI open
@@ -97,9 +98,15 @@ public class AnvilGUI {
         paper.setItemMeta(paperMeta);
         this.insert = paper;
 
-        final Version version = Version.of(Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3]);
-        Validate.notNull(version, "Your server version isn't supported in AnvilGUI!");
-        wrapper = version.getWrapper();
+        final String strVersion = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
+        final Version version = Version.of(strVersion);
+        //Validate.notNull(version, "Your server version isn't supported in AnvilGUI!");
+        if (version != null)
+            wrapper = version.getWrapper();
+        else {
+            plugin.getLogger().warning("[AnvilGUI] Using fallback wrapper, please ask the developers to implement \"" + strVersion + "\" too (" + GITHUB_LINK + ")");
+            wrapper = Version.getFallback();
+        }
 
         wrapper.handleInventoryCloseEvent(holder);
         wrapper.setActiveContainerDefault(holder);

--- a/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -12,6 +12,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.AnvilInventory;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -168,7 +169,11 @@ public class AnvilGUI {
 
         @EventHandler
         public void onInventoryClose(InventoryCloseEvent e) {
-            if(open && e.getInventory().equals(inventory)) closeInventory();
+            if(e.getInventory().equals(inventory)) {
+                if(open)
+                    closeInventory();
+                e.getInventory().clear();
+            }
         }
 
     }

--- a/src/main/java/net/wesjd/anvilgui/version/Version.java
+++ b/src/main/java/net/wesjd/anvilgui/version/Version.java
@@ -58,6 +58,7 @@ public enum Version {
                             return aClass.newInstance();
                         }
                     });
+    private static FallbackWrapper fallback = null;
 
     /**
      * The package value of this NMS version
@@ -105,6 +106,12 @@ public enum Version {
      */
     public static Version of(final String pkg) {
         return Arrays.stream(values()).filter(ver -> pkg.equals("v" + ver.getPkg())).findFirst().orElse(null);
+    }
+
+    public static FallbackWrapper getFallback() {
+        if(fallback == null)
+            fallback = new FallbackWrapper();
+        return fallback;
     }
 
 }

--- a/src/main/java/net/wesjd/anvilgui/version/impl/FallbackWrapper.java
+++ b/src/main/java/net/wesjd/anvilgui/version/impl/FallbackWrapper.java
@@ -11,6 +11,17 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+/**
+ * This class tries to do what all the other wrappers did but using reflections, this doesn't require the version to be
+ * known compile-time but it has some really serious drawbacks: it's slower, dirtier and it could not work in newer versions
+ *
+ * in the static block we init every used reflection util, the classes are named &lt;className&gt;Class (like playerClass),
+ * the methods are named &lt;className&gt;&lt;methodName&gt; (like playerGetHandle),
+ * constructors are named &lt;className&gt;Constructor (like chatMessageConstructor),
+ * fields are named &lt;className&gt;&lt;fieldName&gt; (like playerActiveContainer)
+ *
+ * Every method written with reflection has his real-code version commented before
+ */
 public class FallbackWrapper implements VersionWrapper {
     private static final String version;
 

--- a/src/main/java/net/wesjd/anvilgui/version/impl/FallbackWrapper.java
+++ b/src/main/java/net/wesjd/anvilgui/version/impl/FallbackWrapper.java
@@ -242,7 +242,12 @@ public class FallbackWrapper implements VersionWrapper {
      */
     @Override
     public Object newContainerAnvil(Player player) {
-        //TODO try to make containerAnvil.a() return always true
+        /*
+        This is a workaround for the ContainerAnvil overridation:
+        Instead of overriding the method a() and forcing it to return true
+        We set the container.checkReachable flag, making the method always return true
+         */
+
         try {
             final Object nms = toNMS(player);
             Object obj = containerAnvilConstructor.newInstance(

--- a/src/main/java/net/wesjd/anvilgui/version/impl/FallbackWrapper.java
+++ b/src/main/java/net/wesjd/anvilgui/version/impl/FallbackWrapper.java
@@ -1,0 +1,286 @@
+package net.wesjd.anvilgui.version.impl;
+
+import net.wesjd.anvilgui.version.VersionWrapper;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryView;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class FallbackWrapper implements VersionWrapper {
+    private static final String version;
+
+    private static final Class<?> playerClass;
+    private static final Method playerGetHandle;
+
+    private static final Method playerNextContainerCounter;
+
+    private static final Class<?> craftEventFactory;
+    private static final Method eventFactoryHandleInventoryCloseEvent;
+
+    private static final Field playerPlayerConnection;
+    private static final Class<?> playerConnectionClass;
+    private static final Class<?> packetClass;
+    private static final Method playerConnectionSendPacket;
+    private static final Constructor<?> packetPlayOutOpenWindowConstructor;
+    private static final Class<?> chatMessageClass;
+    private static final Constructor<?> chatMessageConstructor;
+    private static final String blockAnvilA;
+
+    private static final Constructor<?> packetPlayOutCloseWindowConstructor;
+
+    private static final Field playerActiveContainer, playerDefaultContainer;
+
+    private static final Field containerWindowId;
+
+    private static final Method containerAddSlotListener;
+
+    private static final Method containerGetBukkitView;
+
+    private static final Field playerInventory, playerWorld;
+    private static final Object blockPositionZero;
+    private static final Constructor<?> containerAnvilConstructor;
+    private static final Field containerCheckReachable;
+
+    static {
+        version = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
+        try {
+            playerClass = getNMSClass("EntityPlayer");
+
+            playerGetHandle = getCraftClass("entity.CraftPlayer").getMethod("getHandle");
+
+            playerNextContainerCounter = playerClass.getMethod("nextContainerCounter");
+
+            craftEventFactory = getCraftClass("event.CraftEventFactory");
+            eventFactoryHandleInventoryCloseEvent = craftEventFactory.getMethod("handleInventoryCloseEvent", getNMSClass("EntityHuman"));
+
+            playerPlayerConnection = playerClass.getField("playerConnection");
+            playerConnectionClass = getNMSClass("PlayerConnection");
+            packetClass = getNMSClass("Packet");
+            playerConnectionSendPacket = playerConnectionClass.getMethod("sendPacket", packetClass);
+            final Class<?> packetPlayOutOpenWindowClass = getNMSClass("PacketPlayOutOpenWindow");
+            packetPlayOutOpenWindowConstructor = packetPlayOutOpenWindowClass.getConstructor(Integer.TYPE, String.class, getNMSClass("IChatBaseComponent"));
+            chatMessageClass = getNMSClass("ChatMessage");
+            chatMessageConstructor = chatMessageClass.getConstructor(String.class, Object[].class);
+            final Class<?> blockClass = getNMSClass("Block");
+            final Method blockA = blockClass.getMethod("a");
+            final Object blocksAnvil = getNMSClass("Blocks").getField("ANVIL").get(null);
+            blockAnvilA = (String) blockA.invoke(blocksAnvil);
+
+            final Class<?> packetPlayOutCloseWindowClass = getNMSClass("PacketPlayOutCloseWindow");
+            packetPlayOutCloseWindowConstructor = packetPlayOutCloseWindowClass.getConstructor(Integer.TYPE);
+
+            playerActiveContainer = playerClass.getField("activeContainer");
+            playerDefaultContainer = playerClass.getField("defaultContainer");
+
+            final Class<?> containerClass = getNMSClass("Container");
+            containerWindowId = containerClass.getField("windowId");
+
+            containerAddSlotListener = containerClass.getMethod("addSlotListener", getNMSClass("ICrafting"));
+
+            containerGetBukkitView = containerClass.getMethod("getBukkitView");
+
+            playerInventory = playerClass.getField("inventory");
+            playerWorld = playerClass.getField("world");
+            final Class<?> blockPositionClass = getNMSClass("BlockPosition");
+            blockPositionZero = blockPositionClass.getField("ZERO").get(null);
+
+            containerAnvilConstructor = getNMSClass("ContainerAnvil").getConstructor(
+                    getNMSClass("PlayerInventory"),
+                    getNMSClass("World"),
+                    blockPositionClass,
+                    getNMSClass("EntityHuman")
+            );
+            containerCheckReachable = getNMSClass("Container").getField("checkReachable");
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getNextContainerId(Player player) {
+        //return nms(player).nextContainerCounter();
+        try {
+            return (int) playerNextContainerCounter.invoke(toNMS(player));//nms(player).nextContainerCounter();
+        } catch (Exception e) {
+            //TODO better errors;
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void handleInventoryCloseEvent(Player player) {
+        //CraftEventFactory.handleInventoryCloseEvent(nms(player));
+        try {
+            eventFactoryHandleInventoryCloseEvent.invoke(craftEventFactory, toNMS(player));
+        } catch (Exception e) {
+            //TODO better errors;
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void sendPacketOpenWindow(Player player, int containerId) {
+        //toNMS(player).playerConnection.sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
+        try {
+            playerConnectionSendPacket.invoke(//.sendPacket(
+                    playerPlayerConnection.get(toNMS(player)),//nms(player).playerConnection
+                    packetPlayOutOpenWindowConstructor.newInstance(//new PlayOutOpenWindow(
+                            containerId,
+                            "minecraft:anvil",
+                            chatMessageConstructor.newInstance(blockAnvilA + ".name", new Object[]{})//Blocks.ANVIL.a() + ".name"
+                    )//)
+            );//);
+        } catch (Exception e) {
+           //TODO better errors;
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void sendPacketCloseWindow(Player player, int containerId) {
+        // nms(player).playerConnection.sendPacket(new PacketPlayOutCloseWindow(containerId));
+        try {
+            playerConnectionSendPacket.invoke(//.sendPacket(
+                    playerPlayerConnection.get(toNMS(player)),//nms(player).playerConnection
+                    packetPlayOutCloseWindowConstructor.newInstance(containerId)//new PacketPlayOutCloseWindow(containerId)
+            );//);
+        } catch (Exception e) {
+            //TODO better errors;
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setActiveContainerDefault(Player player) {
+        try {
+            Object nmsPlayer = toNMS(player);
+            playerActiveContainer.set(nmsPlayer, playerDefaultContainer.get(nmsPlayer));
+        } catch (Exception e) {
+            //TODO better errors;
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setActiveContainer(Player player, Object container) {
+        try {
+            playerActiveContainer.set(toNMS(player), container);
+        } catch (Exception e) {
+            //TODO better errors;
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setActiveContainerId(Object container, int containerId) {
+        try {
+            containerWindowId.set(container, containerId);
+        } catch (Exception e) {
+            //TODO better errors;
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addActiveContainerSlotListener(Object container, Player player) {
+        try {
+            containerAddSlotListener.invoke(container, toNMS(player));
+        } catch (Exception e) {
+            //TODO better errors;
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Inventory toBukkitInventory(Object container) {
+        try {
+            return ((InventoryView)containerGetBukkitView.invoke(container)).getTopInventory();
+        } catch (Exception e) {
+            //TODO better errors;
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object newContainerAnvil(Player player) {
+        //TODO try to make containerAnvil.a() return always true
+        try {
+            final Object nms = toNMS(player);
+            Object obj = containerAnvilConstructor.newInstance(
+                    playerInventory.get(nms),
+                    playerWorld.get(nms),
+                    blockPositionZero,
+                    nms
+            );
+            containerCheckReachable.set(obj, false);
+            return obj;
+        } catch (Exception e) {
+            //TODO better errors;
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * Turns a {@link Player} into an NMS one
+     * @param player The player to be converted
+     * @return the NMS EntityPlayer
+     */
+    private Object toNMS(Player player) throws InvocationTargetException, IllegalAccessException {
+        return playerGetHandle.invoke(player);
+    }
+
+
+    private static Class<?> getNMSClass(String name) {
+        try {
+            return Class.forName("net.minecraft.server." + version + "." + name);
+        } catch(ClassNotFoundException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    private static Class<?> getCraftClass(String path) {
+        try {
+            return Class.forName("org.bukkit.craftbukkit." + version + "." + path);
+        } catch(ClassNotFoundException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+}

--- a/src/main/java/net/wesjd/anvilgui/version/impl/FallbackWrapper.java
+++ b/src/main/java/net/wesjd/anvilgui/version/impl/FallbackWrapper.java
@@ -97,8 +97,7 @@ public class FallbackWrapper implements VersionWrapper {
             );
             containerCheckReachable = getNMSClass("Container").getField("checkReachable");
         } catch (Exception e) {
-            e.printStackTrace();
-            throw new IllegalStateException(e);
+            throw new UnsupportedVersionException(version, e);
         }
     }
 
@@ -111,8 +110,8 @@ public class FallbackWrapper implements VersionWrapper {
         try {
             return (int) playerNextContainerCounter.invoke(toNMS(player));//nms(player).nextContainerCounter();
         } catch (Exception e) {
-            //TODO better errors;
-            throw new IllegalStateException(e);
+            handleException(e);
+            return -1;
         }
     }
 
@@ -125,8 +124,7 @@ public class FallbackWrapper implements VersionWrapper {
         try {
             eventFactoryHandleInventoryCloseEvent.invoke(craftEventFactory, toNMS(player));
         } catch (Exception e) {
-            //TODO better errors;
-            throw new IllegalStateException(e);
+            handleException(e);
         }
     }
 
@@ -146,8 +144,7 @@ public class FallbackWrapper implements VersionWrapper {
                     )//)
             );//);
         } catch (Exception e) {
-           //TODO better errors;
-            throw new IllegalStateException(e);
+           handleException(e);
         }
     }
 
@@ -163,8 +160,7 @@ public class FallbackWrapper implements VersionWrapper {
                     packetPlayOutCloseWindowConstructor.newInstance(containerId)//new PacketPlayOutCloseWindow(containerId)
             );//);
         } catch (Exception e) {
-            //TODO better errors;
-            throw new IllegalStateException(e);
+            handleException(e);
         }
     }
 
@@ -177,8 +173,7 @@ public class FallbackWrapper implements VersionWrapper {
             Object nmsPlayer = toNMS(player);
             playerActiveContainer.set(nmsPlayer, playerDefaultContainer.get(nmsPlayer));
         } catch (Exception e) {
-            //TODO better errors;
-            throw new IllegalStateException(e);
+            handleException(e);
         }
     }
 
@@ -190,8 +185,7 @@ public class FallbackWrapper implements VersionWrapper {
         try {
             playerActiveContainer.set(toNMS(player), container);
         } catch (Exception e) {
-            //TODO better errors;
-            throw new IllegalStateException(e);
+            handleException(e);
         }
     }
 
@@ -203,8 +197,7 @@ public class FallbackWrapper implements VersionWrapper {
         try {
             containerWindowId.set(container, containerId);
         } catch (Exception e) {
-            //TODO better errors;
-            throw new IllegalStateException(e);
+            handleException(e);
         }
     }
 
@@ -216,8 +209,7 @@ public class FallbackWrapper implements VersionWrapper {
         try {
             containerAddSlotListener.invoke(container, toNMS(player));
         } catch (Exception e) {
-            //TODO better errors;
-            throw new IllegalStateException(e);
+            handleException(e);
         }
     }
 
@@ -229,8 +221,8 @@ public class FallbackWrapper implements VersionWrapper {
         try {
             return ((InventoryView)containerGetBukkitView.invoke(container)).getTopInventory();
         } catch (Exception e) {
-            //TODO better errors;
-            throw new IllegalStateException(e);
+            handleException(e);
+            return null;
         }
     }
 
@@ -251,8 +243,8 @@ public class FallbackWrapper implements VersionWrapper {
             containerCheckReachable.set(obj, false);
             return obj;
         } catch (Exception e) {
-            //TODO better errors;
-            throw new IllegalStateException(e);
+            handleException(e);
+            return null;
         }
     }
 
@@ -263,6 +255,10 @@ public class FallbackWrapper implements VersionWrapper {
      */
     private Object toNMS(Player player) throws InvocationTargetException, IllegalAccessException {
         return playerGetHandle.invoke(player);
+    }
+
+    protected void handleException(Exception e) {
+        throw new UnsupportedVersionException(version, e);
     }
 
 
@@ -281,6 +277,19 @@ public class FallbackWrapper implements VersionWrapper {
         } catch(ClassNotFoundException e) {
             e.printStackTrace();
             return null;
+        }
+    }
+
+    public static class UnsupportedVersionException extends RuntimeException {
+        private final String version;
+
+        public UnsupportedVersionException(String version, Exception e) {
+            super("Unsupported version \"" + version + "\", report this to the developers", e);
+            this.version = version;
+        }
+
+        public String getVersion() {
+            return version;
         }
     }
 }


### PR DESCRIPTION
The commits [686934a, 6210ef2, 1923e69, 2b55567] add a new Wrapper that's used instead of the version-based ones if no supported version is found.
The commit 4adf39d is only a fix that removes the ItemStack used in the anvil when the inventory is closing.
(this time there are only the right commits)