### PR TITLE
Added support for spigot 1.12.2

### DIFF
--- a/src/main/java/net/wesjd/anvilgui/version/impl/Wrapper1_12_R1.java
+++ b/src/main/java/net/wesjd/anvilgui/version/impl/Wrapper1_12_R1.java
@@ -113,7 +113,7 @@ public class Wrapper1_12_R1 implements VersionWrapper {
         }
 
         @Override
-        public boolean a(EntityHuman entityhuman) {
+        public boolean canUse(EntityHuman entityhuman) {
             return true;
         }
 

--- a/src/main/java/net/wesjd/anvilgui/version/impl/Wrapper1_12_R1.java
+++ b/src/main/java/net/wesjd/anvilgui/version/impl/Wrapper1_12_R1.java
@@ -110,11 +110,7 @@ public class Wrapper1_12_R1 implements VersionWrapper {
 
         public AnvilContainer(EntityHuman entityhuman) {
             super(entityhuman.inventory, entityhuman.world, new BlockPosition(0, 0, 0), entityhuman);
-        }
-
-        @Override
-        public boolean canUse(EntityHuman entityhuman) {
-            return true;
+            this.checkReachable = false;
         }
 
     }


### PR DESCRIPTION
The vanilla class _ContainerAnvil_ have changed on spigot 1.12.2. The method used in the Wrapper classes is now called _canUse(...)_ instead of _a(..)_.