### PR TITLE
Add facade method to retrieve the result via CompletableFuture

### DIFF
--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -16,6 +16,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.Plugin;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 
 /**
@@ -134,6 +135,30 @@ public class AnvilGUI {
      */
     public Inventory getInventory() {
         return inventory;
+    }
+
+    /**
+     * Opens an AnvilGUI for a player and returns the future response
+     * @param plugin The {@link org.bukkit.plugin.java.JavaPlugin} instance
+     * @param holder The {@link Player] to open the inventory for}
+     * @param insert What to have the text already set to
+     * @return A future that will be completed with the player's response
+     * @throws NullPointerException If the server version isn't supported
+     */
+    public static CompletableFuture<String> open(Plugin plugin, Player holder, String insert) {
+        CompletableFuture<String> yield = new CompletableFuture<>();
+
+        Bukkit.getScheduler()
+                .runTask(plugin, () -> {
+                    AnvilGUI[] inst = new AnvilGUI[1];
+                    inst[0] = new AnvilGUI(plugin, holder, insert, (player, response) -> {
+                        inst[0].closeInventory();
+                        yield.complete(response);
+                        return response;
+                    });
+                });
+
+        return yield;
     }
 
     /**


### PR DESCRIPTION
Have just been checking this project out, and I am very happy to see that there is people creating this kind of stuff, so I don't have to deal with it.
However, when trying to use it, I ran into a problem:
It seemed to me that you have to close the Anvil inventory manually by calling `AnvilGUI#closeInventory()`, and that is a bad solution if you just want one single input, because you would then have to call that method while inside the constructor of the object that you need to call the method on. I have figured out a workaround to this by doing the following:
```java
AnvilGUI[] anvilGui = new AnvilGUI[1]; // create array of AnvilGUI
anvilGui[0] = new AnvilGUI( // write to that array while constructing
        this, // my plugin
        player, // the player
        "anvilGui",
        (plr, result) -> { 
/* this is the BiFunction, this will always be called later from another thread, so we can assert that the
   AnvilGUI object has alread been put into the array. */
            anvilGui[0].closeInventory(); // access this object through the array and close the inventory
            System.out.println("result = " + result); // handle the result, in this case, just print it to console
            return result; // return the result
        });
```
In this particular example, I am just trying to print the result from the GUI.

With the changes applied by this PR, the enduser will be able to create an AnvilGUI by a simple facade method: `AnvilGUI#open`, if they just need to retrieve one single line of input.
The new usage can look like this:
```java
AnvilGUI.open(this, player, "i am an anvil")
        .thenAcceptAsync(System.out::println);
```
This will open an AnvilGUI, let the player input one line and then push that input to the returned CompletableFuture and close the GUI.

I hope that think the same about that this change might be helpful to some people, but I am also looking forward to applying changes that you may request.