### PR TITLE
Add ability to customize ItemStack in build pattern.

### DIFF
--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -334,7 +334,7 @@ public class AnvilGUI {
      * Sets the ItemStack that will be inserted into the
      * Anvil GUI.
      *
-     * @param itemStack The {@link ItemStack that will be displayed}
+     * @param itemStack The {@link ItemStack} that will be displayed
      * @return The {@link Builder} instance
      * @throws IllegalArgumentException if the {@link ItemStack} is null
      */

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -16,6 +16,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.Plugin;
 
+import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
@@ -27,365 +28,406 @@ import java.util.function.Consumer;
  */
 public class AnvilGUI {
 
-	/**
-	 * The local {@link VersionWrapper} object for the server's version
-	 */
-	private static VersionWrapper WRAPPER = new VersionMatcher().match();
+  /**
+   * The local {@link VersionWrapper} object for the server's version
+   */
+  private static VersionWrapper WRAPPER = new VersionMatcher().match();
 
-	/**
-	 * The {@link Plugin} that this anvil GUI is associated with
-	 */
-	private final Plugin plugin;
-	/**
-	 * The player who has the GUI open
-	 */
-	private final Player player;
-	/**
-	 * The text that will be displayed to the user
-	 */
-	private String text = "";
-	/**
-	 * A state that decides where the anvil GUI is able to be closed by the user
-	 */
-	private final boolean preventClose;
-	/**
-	 * An {@link Consumer} that is called when the anvil GUI is closed
-	 */
-	private final Consumer<Player> closeListener;
-	/**
-	 * An {@link BiFunction} that is called when the {@link Slot#OUTPUT} slot has been clicked
-	 */
-	private final BiFunction<Player, String, Response> completeFunction;
+  /**
+   * The {@link Plugin} that this anvil GUI is associated with
+   */
+  private final Plugin plugin;
+  /**
+   * The player who has the GUI open
+   */
+  private final Player player;
+  /**
+   * The text that will be displayed to the user
+   */
+  private String text = "";
+  /**
+   * A state that decides where the anvil GUI is able to be closed by the user
+   */
+  private final boolean preventClose;
+  /**
+   * An {@link Consumer} that is called when the anvil GUI is closed
+   */
+  private final Consumer<Player> closeListener;
+  /**
+   * An {@link BiFunction} that is called when the {@link Slot#OUTPUT} slot has been clicked
+   */
+  private final BiFunction<Player, String, Response> completeFunction;
 
-	/**
-	 * The ItemStack that is in the {@link Slot#INPUT_LEFT} slot.
-	 */
-	private ItemStack insert;
-	/**
-	 * The container id of the inventory, used for NMS methods
-	 */
-	private int containerId;
-	/**
-	 * The inventory that is used on the Bukkit side of things
-	 */
-	private Inventory inventory;
-	/**
-	 * The listener holder class
-	 */
-	private final ListenUp listener = new ListenUp();
+  /**
+   * The ItemStack that is in the {@link Slot#INPUT_LEFT} slot.
+   */
+  private ItemStack insert;
+  /**
+   * The container id of the inventory, used for NMS methods
+   */
+  private int containerId;
+  /**
+   * The inventory that is used on the Bukkit side of things
+   */
+  private Inventory inventory;
+  /**
+   * The listener holder class
+   */
+  private final ListenUp listener = new ListenUp();
 
-	/**
-	 * Represents the state of the inventory being open
-	 */
-	private boolean open;
+  /**
+   * Represents the state of the inventory being open
+   */
+  private boolean open;
 
-	/**
-	 * Create an AnvilGUI and open it for the player.
-	 *
-	 * @param plugin     A {@link org.bukkit.plugin.java.JavaPlugin} instance
-	 * @param holder     The {@link Player} to open the inventory for
-	 * @param insert     What to have the text already set to
-	 * @param biFunction A {@link BiFunction} that is called when the player clicks the {@link Slot#OUTPUT} slot
-	 * @throws NullPointerException If the server version isn't supported
-	 * @deprecated As of version 1.2.3, use {@link AnvilGUI.Builder}
-	 */
-	@Deprecated
-	public AnvilGUI(Plugin plugin, Player holder, String insert, BiFunction<Player, String, String> biFunction) {
-		this(plugin, holder, insert, false, null, (player, text) -> {
-			String response = biFunction.apply(player, text);
-			if(response != null) {
-				return Response.text(response);
-			} else {
-				return Response.close();
-			}
-		});
-	}
+  /**
+   * Create an AnvilGUI and open it for the player.
+   *
+   * @param plugin     A {@link org.bukkit.plugin.java.JavaPlugin} instance
+   * @param holder     The {@link Player} to open the inventory for
+   * @param insert     What to have the text already set to
+   * @param biFunction A {@link BiFunction} that is called when the player clicks the {@link Slot#OUTPUT} slot
+   * @throws NullPointerException If the server version isn't supported
+   * @deprecated As of version 1.2.3, use {@link AnvilGUI.Builder}
+   */
+  @Deprecated
+  public AnvilGUI(Plugin plugin, Player holder, String inputMessage, ItemStack insert, BiFunction<Player, String, String> biFunction) {
+    this(plugin, holder, inputMessage, insert, false, null, (player, text) -> {
+      String response = biFunction.apply(player, text);
+      if (response != null) {
+        return Response.text(response);
+      } else {
+        return Response.close();
+      }
+    });
+  }
 
-	/**
-	 * Create an AnvilGUI and open it for the player.
-	 *
-	 * @param plugin A {@link org.bukkit.plugin.java.JavaPlugin} instance
-	 * @param player The {@link Player} to open the inventory for
-	 * @param text What to have the text already set to
-	 * @param preventClose Whether to prevent the inventory from closing
-	 * @param closeListener A {@link Consumer} when the inventory closes
-	 * @param completeFunction A {@link BiFunction} that is called when the player clicks the {@link Slot#OUTPUT} slot
-	 */
-	private AnvilGUI(
-			Plugin plugin,
-			Player player,
-			String text,
-			boolean preventClose,
-			Consumer<Player> closeListener,
-			BiFunction<Player, String, Response> completeFunction
-	) {
-		this.plugin = plugin;
-		this.player = player;
-		this.text = text;
-		this.preventClose = preventClose;
-		this.closeListener = closeListener;
-		this.completeFunction = completeFunction;
-		openInventory();
-	}
+  /**
+   * Create an AnvilGUI and open it for the player.
+   *
+   * @param plugin           A {@link org.bukkit.plugin.java.JavaPlugin} instance
+   * @param player           The {@link Player} to open the inventory for
+   * @param text             What to have the text already set to
+   * @param preventClose     Whether to prevent the inventory from closing
+   * @param closeListener    A {@link Consumer} when the inventory closes
+   * @param completeFunction A {@link BiFunction} that is called when the player clicks the {@link Slot#OUTPUT} slot
+   */
+  private AnvilGUI(
+          Plugin plugin,
+          Player player,
+          String text,
+          ItemStack insert,
+          boolean preventClose,
+          Consumer<Player> closeListener,
+          BiFunction<Player, String, Response> completeFunction
+  ) {
+    this.plugin = plugin;
+    this.player = player;
+    this.text = text;
+    this.preventClose = preventClose;
+    this.closeListener = closeListener;
+    this.completeFunction = completeFunction;
+    this.insert = insert;
+    openInventory();
+  }
 
-	/**
-	 * Opens the anvil GUI
-	 */
-	private void openInventory() {
-		final ItemStack paper = new ItemStack(Material.PAPER);
-		final ItemMeta paperMeta = paper.getItemMeta();
-		paperMeta.setDisplayName(text);
-		paper.setItemMeta(paperMeta);
-		this.insert = paper;
+  /**
+   * Opens the anvil GUI
+   */
+  private void openInventory() {
+    this.insert = Objects.isNull(insert) ? makeDefaultItemStack(text) : insert;
 
-		WRAPPER.handleInventoryCloseEvent(player);
-		WRAPPER.setActiveContainerDefault(player);
+    WRAPPER.handleInventoryCloseEvent(player);
+    WRAPPER.setActiveContainerDefault(player);
 
-		Bukkit.getPluginManager().registerEvents(listener, plugin);
+    Bukkit.getPluginManager().registerEvents(listener, plugin);
 
-		final Object container = WRAPPER.newContainerAnvil(player);
+    final Object container = WRAPPER.newContainerAnvil(player);
 
-		inventory = WRAPPER.toBukkitInventory(container);
-		inventory.setItem(Slot.INPUT_LEFT, this.insert);
+    inventory = WRAPPER.toBukkitInventory(container);
+    inventory.setItem(Slot.INPUT_LEFT, this.insert);
 
-		containerId = WRAPPER.getNextContainerId(player);
-		WRAPPER.sendPacketOpenWindow(player, containerId);
-		WRAPPER.setActiveContainer(player, container);
-		WRAPPER.setActiveContainerId(container, containerId);
-		WRAPPER.addActiveContainerSlotListener(container, player);
-		open = true;
-	}
+    containerId = WRAPPER.getNextContainerId(player);
+    WRAPPER.sendPacketOpenWindow(player, containerId);
+    WRAPPER.setActiveContainer(player, container);
+    WRAPPER.setActiveContainerId(container, containerId);
+    WRAPPER.addActiveContainerSlotListener(container, player);
+    open = true;
+  }
 
-	/**
-	 * Closes the inventory if it's open.
-	 *
-	 * @throws IllegalArgumentException If the inventory isn't open
-	 */
-	public void closeInventory() {
-		Validate.isTrue(open, "You can't close an inventory that isn't open!");
-		open = false;
+  /**
+   * Makes the default {@link ItemStack} when it has not been
+   * provided by the {@link AnvilGUI.Builder}.
+   *
+   * @param text The default {@link String} that you want to inset.
+   * @return A default {@link ItemStack} to insert to the GUI.
+   */
+  private ItemStack makeDefaultItemStack(String text) {
+    final ItemStack paper = new ItemStack(Material.PAPER);
+    final ItemMeta paperMeta = paper.getItemMeta();
+    paperMeta.setDisplayName(text);
+    paper.setItemMeta(paperMeta);
+    return paper;
+  }
 
-		WRAPPER.handleInventoryCloseEvent(player);
-		WRAPPER.setActiveContainerDefault(player);
-		WRAPPER.sendPacketCloseWindow(player, containerId);
+  /**
+   * Closes the inventory if it's open.
+   *
+   * @throws IllegalArgumentException If the inventory isn't open
+   */
+  public void closeInventory() {
+    Validate.isTrue(open, "You can't close an inventory that isn't open!");
+    open = false;
 
-		HandlerList.unregisterAll(listener);
+    WRAPPER.handleInventoryCloseEvent(player);
+    WRAPPER.setActiveContainerDefault(player);
+    WRAPPER.sendPacketCloseWindow(player, containerId);
 
-		if(closeListener != null) {
-			closeListener.accept(player);
-		}
-	}
+    HandlerList.unregisterAll(listener);
 
-	/**
-	 * Returns the Bukkit inventory for this anvil gui
-	 * @return the {@link Inventory} for this anvil gui
-	 */
-	public Inventory getInventory() {
-		return inventory;
-	}
+    if (closeListener != null) {
+      closeListener.accept(player);
+    }
+  }
 
-	/**
-	 * Simply holds the listeners for the GUI
-	 */
-	private class ListenUp implements Listener {
+  /**
+   * Returns the Bukkit inventory for this anvil gui
+   *
+   * @return the {@link Inventory} for this anvil gui
+   */
+  public Inventory getInventory() {
+    return inventory;
+  }
 
-		@EventHandler
-		public void onInventoryClick(InventoryClickEvent event) {
-			if (event.getInventory().equals(inventory) && event.getRawSlot() < 3) {
-				event.setCancelled(true);
-				final Player clicker = (Player) event.getWhoClicked();
-				if (event.getRawSlot() == Slot.OUTPUT) {
-					final ItemStack clicked = inventory.getItem(Slot.OUTPUT);
-					if (clicked == null || clicked.getType() == Material.AIR) return;
+  /**
+   * Simply holds the listeners for the GUI
+   */
+  private class ListenUp implements Listener {
 
-					final Response response = completeFunction.apply(clicker, clicked.hasItemMeta() ? clicked.getItemMeta().getDisplayName() : "");
-					if(response.getText() != null) {
-						final ItemMeta meta = clicked.getItemMeta();
-						meta.setDisplayName(response.getText());
-						clicked.setItemMeta(meta);
-						inventory.setItem(Slot.INPUT_LEFT, clicked);
-					} else {
-						closeInventory();
-					}
-				}
-			}
-		}
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+      if (event.getInventory().equals(inventory) && event.getRawSlot() < 3) {
+        event.setCancelled(true);
+        final Player clicker = (Player) event.getWhoClicked();
+        if (event.getRawSlot() == Slot.OUTPUT) {
+          final ItemStack clicked = inventory.getItem(Slot.OUTPUT);
+          if (clicked == null || clicked.getType() == Material.AIR) return;
 
-		@EventHandler
-		public void onInventoryClose(InventoryCloseEvent event) {
-			if (open && event.getInventory().equals(inventory)) {
-				closeInventory();
-				if(preventClose) {
-					Bukkit.getScheduler().runTask(plugin, AnvilGUI.this::openInventory);
-				}
-			}
-		}
+          final Response response = completeFunction.apply(clicker, clicked.hasItemMeta() ? clicked.getItemMeta().getDisplayName() : "");
+          if (response.getText() != null) {
+            final ItemMeta meta = clicked.getItemMeta();
+            meta.setDisplayName(response.getText());
+            clicked.setItemMeta(meta);
+            inventory.setItem(Slot.INPUT_LEFT, clicked);
+          } else {
+            closeInventory();
+          }
+        }
+      }
+    }
 
-	}
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+      if (open && event.getInventory().equals(inventory)) {
+        closeInventory();
+        if (preventClose) {
+          Bukkit.getScheduler().runTask(plugin, AnvilGUI.this::openInventory);
+        }
+      }
+    }
 
-	/**
-	 * A builder class for an {@link AnvilGUI} object
-	 */
-	public static class Builder {
+  }
 
-		/**
-		 * An {@link Consumer} that is called when the anvil GUI is closed
-		 */
-		private Consumer<Player> closeListener;
-		/**
-		 * A state that decides where the anvil GUI is able to be closed by the user
-		 */
-		private boolean preventClose = false;
-		/**
-		 * An {@link BiFunction} that is called when the anvil output slot has been clicked
-		 */
-		private BiFunction<Player, String, Response> completeFunction;
-		/**
-		 * The {@link Plugin} that this anvil GUI is associated with
-		 */
-		private Plugin plugin;
-		/**
-		 * The text that will be displayed to the user
-		 */
-		private String text = "";
+  /**
+   * A builder class for an {@link AnvilGUI} object
+   */
+  public static class Builder {
 
-		/**
-		 * Prevents the closing of the anvil GUI by the user
-		 * @return The {@link Builder} instance
-		 */
-		public Builder preventClose() {
-			preventClose = true;
-			return this;
-		}
+    /**
+     * An {@link Consumer} that is called when the anvil GUI is closed
+     */
+    private Consumer<Player> closeListener;
+    /**
+     * A state that decides where the anvil GUI is able to be closed by the user
+     */
+    private boolean preventClose = false;
+    /**
+     * An {@link BiFunction} that is called when the anvil output slot has been clicked
+     */
+    private BiFunction<Player, String, Response> completeFunction;
+    /**
+     * The {@link Plugin} that this anvil GUI is associated with
+     */
+    private Plugin plugin;
+    /**
+     * The text that will be displayed to the user
+     */
+    private String text = "";
+    /**
+     * The {@link ItemStack} that would get inserted into the GUI.
+     */
+    private ItemStack itemStack;
 
-		/**
-		 * Listens for when the inventory is closed
-		 * @param closeListener An {@link Consumer} that is called when the anvil GUI is closed
-		 * @return The {@link Builder} instance
-		 * @throws IllegalArgumentException when the closeListener is null
-		 */
-		public Builder onClose(Consumer<Player> closeListener) {
-			Validate.notNull(closeListener, "closeListener cannot be null");
-			this.closeListener = closeListener;
-			return this;
-		}
+    /**
+     * Prevents the closing of the anvil GUI by the user
+     *
+     * @return The {@link Builder} instance
+     */
+    public Builder preventClose() {
+      preventClose = true;
+      return this;
+    }
 
-		/**
-		 * Handles the inventory output slot when it is clicked
-		 * @param completeFunction An {@link BiFunction} that is called when the user clicks the output slot
-		 * @return The {@link Builder} instance
-		 * @throws IllegalArgumentException when the completeFunction is null
-		 */
-		public Builder onComplete(BiFunction<Player, String, Response> completeFunction) {
-			Validate.notNull(completeFunction, "Complete function cannot be null");
-			this.completeFunction = completeFunction;
-			return this;
-		}
+    /**
+     * Listens for when the inventory is closed
+     *
+     * @param closeListener An {@link Consumer} that is called when the anvil GUI is closed
+     * @return The {@link Builder} instance
+     * @throws IllegalArgumentException when the closeListener is null
+     */
+    public Builder onClose(Consumer<Player> closeListener) {
+      Validate.notNull(closeListener, "closeListener cannot be null");
+      this.closeListener = closeListener;
+      return this;
+    }
 
-		/**
-		 * Sets the plugin for the {@link AnvilGUI}
-		 * @param plugin The {@link Plugin} this anvil GUI is associated with
-		 * @return The {@link Builder} instance
-		 * @throws IllegalArgumentException if the plugin is null
-		 */
-		public Builder plugin(Plugin plugin) {
-			Validate.notNull(plugin, "Plugin cannot be null");
-			this.plugin = plugin;
-			return this;
-		}
+    /**
+     * Handles the inventory output slot when it is clicked
+     *
+     * @param completeFunction An {@link BiFunction} that is called when the user clicks the output slot
+     * @return The {@link Builder} instance
+     * @throws IllegalArgumentException when the completeFunction is null
+     */
+    public Builder onComplete(BiFunction<Player, String, Response> completeFunction) {
+      Validate.notNull(completeFunction, "Complete function cannot be null");
+      this.completeFunction = completeFunction;
+      return this;
+    }
 
-		/**
-		 * Sets the text that is to be displayed to the user
-		 * @param text The text that is to be displayed to the user
-		 * @return The {@link Builder} instance
-		 * @throws IllegalArgumentException if the text is null
-		 */
-		public Builder text(String text) {
-			Validate.notNull(text, "Text cannot be null");
-			this.text = text;
-			return this;
-		}
+    /**
+     * Sets the plugin for the {@link AnvilGUI}
+     *
+     * @param plugin The {@link Plugin} this anvil GUI is associated with
+     * @return The {@link Builder} instance
+     * @throws IllegalArgumentException if the plugin is null
+     */
+    public Builder plugin(Plugin plugin) {
+      Validate.notNull(plugin, "Plugin cannot be null");
+      this.plugin = plugin;
+      return this;
+    }
 
-		/**
-		 * Creates the anvil GUI and opens it for the player
-		 * @param player The {@link Player} the anvil GUI should open for
-		 * @return The {@link AnvilGUI} instance from this builder
-		 * @throws IllegalArgumentException when the onComplete function, plugin, or player is null
-		 */
-		public AnvilGUI open(Player player) {
-			Validate.notNull(plugin, "Plugin cannot be null");
-			Validate.notNull(completeFunction, "Complete function cannot be null");
-			Validate.notNull(player, "Player cannot be null");
-			return new AnvilGUI(plugin, player, text, preventClose, closeListener, completeFunction);
-		}
+    /**
+     * Sets the text that is to be displayed to the user
+     *
+     * @param text The text that is to be displayed to the user
+     * @return The {@link Builder} instance
+     * @throws IllegalArgumentException if the text is null
+     */
+    public Builder text(String text) {
+      Validate.notNull(text, "Text cannot be null");
+      this.text = text;
+      return this;
+    }
 
-	}
+    /**
+     * Sets the ItemStack that will be inserted into the
+     * Anvil GUI.
+     *
+     * @param itemStack The {@link ItemStack that will be displayed}
+     * @return The {@link Builder} instance
+     * @throws IllegalArgumentException if the {@link ItemStack} is null
+     */
+    public Builder itemStack(ItemStack itemStack) {
+      Validate.notNull(itemStack, "The ItemStack cannot be null");
+      this.itemStack = itemStack;
+      return this;
+    }
 
-	/**
-	 * Represents a response when the player clicks the output item in the anvil GUI
-	 */
-	public static class Response {
+    /**
+     * Creates the anvil GUI and opens it for the player
+     *
+     * @param player The {@link Player} the anvil GUI should open for
+     * @return The {@link AnvilGUI} instance from this builder
+     * @throws IllegalArgumentException when the onComplete function, plugin, or player is null
+     */
+    public AnvilGUI open(Player player) {
+      Validate.notNull(plugin, "Plugin cannot be null");
+      Validate.notNull(completeFunction, "Complete function cannot be null");
+      Validate.notNull(player, "Player cannot be null");
+      return new AnvilGUI(plugin, player, text, itemStack, preventClose, closeListener, completeFunction);
+    }
+  }
 
-		/**
-		 * The text that is to be displayed to the user
-		 */
-		private final String text;
+  /**
+   * Represents a response when the player clicks the output item in the anvil GUI
+   */
+  public static class Response {
 
-		/**
-		 * Creates a response to the user's input
-		 * @param text The text that is to be displayed to the user, which can be null to close the inventory
-		 */
-		private Response(String text) {
-			this.text = text;
-		}
+    /**
+     * The text that is to be displayed to the user
+     */
+    private final String text;
 
-		/**
-		 * Gets the text that is to be displayed to the user
-		 * @return The text that is to be displayed to the user
-		 */
-		public String getText() {
-			return text;
-		}
+    /**
+     * Creates a response to the user's input
+     *
+     * @param text The text that is to be displayed to the user, which can be null to close the inventory
+     */
+    private Response(String text) {
+      this.text = text;
+    }
 
-		/**
-		 * Returns an {@link Response} object for when the anvil GUI is to close
-		 * @return An {@link Response} object for when the anvil GUI is to close
-		 */
-		public static Response close() {
-			return new Response(null);
-		}
+    /**
+     * Gets the text that is to be displayed to the user
+     *
+     * @return The text that is to be displayed to the user
+     */
+    public String getText() {
+      return text;
+    }
 
-		/**
-		 * Returns an {@link Response} object for when the anvil GUI is to display text to the user
-		 * @param text The text that is to be displayed to the user
-		 * @return An {@link Response} object for when the anvil GUI is to display text to the user
-		 */
-		public static Response text(String text) {
-			return new Response(text);
-		}
+    /**
+     * Returns an {@link Response} object for when the anvil GUI is to close
+     *
+     * @return An {@link Response} object for when the anvil GUI is to close
+     */
+    public static Response close() {
+      return new Response(null);
+    }
 
-	}
+    /**
+     * Returns an {@link Response} object for when the anvil GUI is to display text to the user
+     *
+     * @param text The text that is to be displayed to the user
+     * @return An {@link Response} object for when the anvil GUI is to display text to the user
+     */
+    public static Response text(String text) {
+      return new Response(text);
+    }
 
-	/**
-	 * Class wrapping the magic constants of slot numbers in an anvil GUI
-	 */
-	public static class Slot {
+  }
 
-		/**
-		 * The slot on the far left, where the first input is inserted. An {@link ItemStack} is always inserted
-		 * here to be renamed
-		 */
-		public static final int INPUT_LEFT = 0;
-		/**
-		 * Not used, but in a real anvil you are able to put the second item you want to combine here
-		 */
-		public static final int INPUT_RIGHT = 1;
-		/**
-		 * The output slot, where an item is put when two items are combined from {@link #INPUT_LEFT} and
-		 * {@link #INPUT_RIGHT} or {@link #INPUT_LEFT} is renamed
-		 */
-		public static final int OUTPUT = 2;
+  /**
+   * Class wrapping the magic constants of slot numbers in an anvil GUI
+   */
+  public static class Slot {
 
-	}
+    /**
+     * The slot on the far left, where the first input is inserted. An {@link ItemStack} is always inserted
+     * here to be renamed
+     */
+    public static final int INPUT_LEFT = 0;
+    /**
+     * Not used, but in a real anvil you are able to put the second item you want to combine here
+     */
+    public static final int INPUT_RIGHT = 1;
+    /**
+     * The output slot, where an item is put when two items are combined from {@link #INPUT_LEFT} and
+     * {@link #INPUT_RIGHT} or {@link #INPUT_LEFT} is renamed
+     */
+    public static final int OUTPUT = 2;
+
+  }
 
 }

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -28,406 +28,406 @@ import java.util.function.Consumer;
  */
 public class AnvilGUI {
 
-  /**
-   * The local {@link VersionWrapper} object for the server's version
-   */
-  private static VersionWrapper WRAPPER = new VersionMatcher().match();
-
-  /**
-   * The {@link Plugin} that this anvil GUI is associated with
-   */
-  private final Plugin plugin;
-  /**
-   * The player who has the GUI open
-   */
-  private final Player player;
-  /**
-   * The text that will be displayed to the user
-   */
-  private String text = "";
-  /**
-   * A state that decides where the anvil GUI is able to be closed by the user
-   */
-  private final boolean preventClose;
-  /**
-   * An {@link Consumer} that is called when the anvil GUI is closed
-   */
-  private final Consumer<Player> closeListener;
-  /**
-   * An {@link BiFunction} that is called when the {@link Slot#OUTPUT} slot has been clicked
-   */
-  private final BiFunction<Player, String, Response> completeFunction;
-
-  /**
-   * The ItemStack that is in the {@link Slot#INPUT_LEFT} slot.
-   */
-  private ItemStack insert;
-  /**
-   * The container id of the inventory, used for NMS methods
-   */
-  private int containerId;
-  /**
-   * The inventory that is used on the Bukkit side of things
-   */
-  private Inventory inventory;
-  /**
-   * The listener holder class
-   */
-  private final ListenUp listener = new ListenUp();
-
-  /**
-   * Represents the state of the inventory being open
-   */
-  private boolean open;
-
-  /**
-   * Create an AnvilGUI and open it for the player.
-   *
-   * @param plugin     A {@link org.bukkit.plugin.java.JavaPlugin} instance
-   * @param holder     The {@link Player} to open the inventory for
-   * @param insert     What to have the text already set to
-   * @param biFunction A {@link BiFunction} that is called when the player clicks the {@link Slot#OUTPUT} slot
-   * @throws NullPointerException If the server version isn't supported
-   * @deprecated As of version 1.2.3, use {@link AnvilGUI.Builder}
-   */
-  @Deprecated
-  public AnvilGUI(Plugin plugin, Player holder, String inputMessage, ItemStack insert, BiFunction<Player, String, String> biFunction) {
-    this(plugin, holder, inputMessage, insert, false, null, (player, text) -> {
-      String response = biFunction.apply(player, text);
-      if (response != null) {
-        return Response.text(response);
-      } else {
-        return Response.close();
-      }
-    });
-  }
-
-  /**
-   * Create an AnvilGUI and open it for the player.
-   *
-   * @param plugin           A {@link org.bukkit.plugin.java.JavaPlugin} instance
-   * @param player           The {@link Player} to open the inventory for
-   * @param text             What to have the text already set to
-   * @param preventClose     Whether to prevent the inventory from closing
-   * @param closeListener    A {@link Consumer} when the inventory closes
-   * @param completeFunction A {@link BiFunction} that is called when the player clicks the {@link Slot#OUTPUT} slot
-   */
-  private AnvilGUI(
-          Plugin plugin,
-          Player player,
-          String text,
-          ItemStack insert,
-          boolean preventClose,
-          Consumer<Player> closeListener,
-          BiFunction<Player, String, Response> completeFunction
-  ) {
-    this.plugin = plugin;
-    this.player = player;
-    this.text = text;
-    this.preventClose = preventClose;
-    this.closeListener = closeListener;
-    this.completeFunction = completeFunction;
-    this.insert = insert;
-    openInventory();
-  }
-
-  /**
-   * Opens the anvil GUI
-   */
-  private void openInventory() {
-    this.insert = Objects.isNull(insert) ? makeDefaultItemStack(text) : insert;
-
-    WRAPPER.handleInventoryCloseEvent(player);
-    WRAPPER.setActiveContainerDefault(player);
-
-    Bukkit.getPluginManager().registerEvents(listener, plugin);
-
-    final Object container = WRAPPER.newContainerAnvil(player);
-
-    inventory = WRAPPER.toBukkitInventory(container);
-    inventory.setItem(Slot.INPUT_LEFT, this.insert);
-
-    containerId = WRAPPER.getNextContainerId(player);
-    WRAPPER.sendPacketOpenWindow(player, containerId);
-    WRAPPER.setActiveContainer(player, container);
-    WRAPPER.setActiveContainerId(container, containerId);
-    WRAPPER.addActiveContainerSlotListener(container, player);
-    open = true;
-  }
-
-  /**
-   * Makes the default {@link ItemStack} when it has not been
-   * provided by the {@link AnvilGUI.Builder}.
-   *
-   * @param text The default {@link String} that you want to inset.
-   * @return A default {@link ItemStack} to insert to the GUI.
-   */
-  private ItemStack makeDefaultItemStack(String text) {
-    final ItemStack paper = new ItemStack(Material.PAPER);
-    final ItemMeta paperMeta = paper.getItemMeta();
-    paperMeta.setDisplayName(text);
-    paper.setItemMeta(paperMeta);
-    return paper;
-  }
-
-  /**
-   * Closes the inventory if it's open.
-   *
-   * @throws IllegalArgumentException If the inventory isn't open
-   */
-  public void closeInventory() {
-    Validate.isTrue(open, "You can't close an inventory that isn't open!");
-    open = false;
-
-    WRAPPER.handleInventoryCloseEvent(player);
-    WRAPPER.setActiveContainerDefault(player);
-    WRAPPER.sendPacketCloseWindow(player, containerId);
-
-    HandlerList.unregisterAll(listener);
-
-    if (closeListener != null) {
-      closeListener.accept(player);
-    }
-  }
-
-  /**
-   * Returns the Bukkit inventory for this anvil gui
-   *
-   * @return the {@link Inventory} for this anvil gui
-   */
-  public Inventory getInventory() {
-    return inventory;
-  }
-
-  /**
-   * Simply holds the listeners for the GUI
-   */
-  private class ListenUp implements Listener {
-
-    @EventHandler
-    public void onInventoryClick(InventoryClickEvent event) {
-      if (event.getInventory().equals(inventory) && event.getRawSlot() < 3) {
-        event.setCancelled(true);
-        final Player clicker = (Player) event.getWhoClicked();
-        if (event.getRawSlot() == Slot.OUTPUT) {
-          final ItemStack clicked = inventory.getItem(Slot.OUTPUT);
-          if (clicked == null || clicked.getType() == Material.AIR) return;
-
-          final Response response = completeFunction.apply(clicker, clicked.hasItemMeta() ? clicked.getItemMeta().getDisplayName() : "");
-          if (response.getText() != null) {
-            final ItemMeta meta = clicked.getItemMeta();
-            meta.setDisplayName(response.getText());
-            clicked.setItemMeta(meta);
-            inventory.setItem(Slot.INPUT_LEFT, clicked);
-          } else {
-            closeInventory();
-          }
-        }
-      }
-    }
-
-    @EventHandler
-    public void onInventoryClose(InventoryCloseEvent event) {
-      if (open && event.getInventory().equals(inventory)) {
-        closeInventory();
-        if (preventClose) {
-          Bukkit.getScheduler().runTask(plugin, AnvilGUI.this::openInventory);
-        }
-      }
-    }
-
-  }
-
-  /**
-   * A builder class for an {@link AnvilGUI} object
-   */
-  public static class Builder {
-
     /**
-     * An {@link Consumer} that is called when the anvil GUI is closed
+     * The local {@link VersionWrapper} object for the server's version
      */
-    private Consumer<Player> closeListener;
-    /**
-     * A state that decides where the anvil GUI is able to be closed by the user
-     */
-    private boolean preventClose = false;
-    /**
-     * An {@link BiFunction} that is called when the anvil output slot has been clicked
-     */
-    private BiFunction<Player, String, Response> completeFunction;
+    private static VersionWrapper WRAPPER = new VersionMatcher().match();
+
     /**
      * The {@link Plugin} that this anvil GUI is associated with
      */
-    private Plugin plugin;
+    private final Plugin plugin;
+    /**
+     * The player who has the GUI open
+     */
+    private final Player player;
     /**
      * The text that will be displayed to the user
      */
     private String text = "";
     /**
-     * The {@link ItemStack} that would get inserted into the GUI.
+     * A state that decides where the anvil GUI is able to be closed by the user
      */
-    private ItemStack itemStack;
+    private final boolean preventClose;
+    /**
+     * An {@link Consumer} that is called when the anvil GUI is closed
+     */
+    private final Consumer<Player> closeListener;
+    /**
+     * An {@link BiFunction} that is called when the {@link Slot#OUTPUT} slot has been clicked
+     */
+    private final BiFunction<Player, String, Response> completeFunction;
 
     /**
-     * Prevents the closing of the anvil GUI by the user
-     *
-     * @return The {@link Builder} instance
+     * The ItemStack that is in the {@link Slot#INPUT_LEFT} slot.
      */
-    public Builder preventClose() {
-      preventClose = true;
-      return this;
+    private ItemStack insert;
+    /**
+     * The container id of the inventory, used for NMS methods
+     */
+    private int containerId;
+    /**
+     * The inventory that is used on the Bukkit side of things
+     */
+    private Inventory inventory;
+    /**
+     * The listener holder class
+     */
+    private final ListenUp listener = new ListenUp();
+
+    /**
+     * Represents the state of the inventory being open
+     */
+    private boolean open;
+
+    /**
+     * Create an AnvilGUI and open it for the player.
+     *
+     * @param plugin     A {@link org.bukkit.plugin.java.JavaPlugin} instance
+     * @param holder     The {@link Player} to open the inventory for
+     * @param insert     What to have the text already set to
+     * @param biFunction A {@link BiFunction} that is called when the player clicks the {@link Slot#OUTPUT} slot
+     * @throws NullPointerException If the server version isn't supported
+     * @deprecated As of version 1.2.3, use {@link AnvilGUI.Builder}
+     */
+    @Deprecated
+    public AnvilGUI(Plugin plugin, Player holder, String inputMessage, ItemStack insert, BiFunction<Player, String, String> biFunction) {
+        this(plugin, holder, inputMessage, insert, false, null, (player, text) -> {
+            String response = biFunction.apply(player, text);
+            if (response != null) {
+                return Response.text(response);
+            } else {
+                return Response.close();
+            }
+        });
     }
 
     /**
-     * Listens for when the inventory is closed
+     * Create an AnvilGUI and open it for the player.
      *
-     * @param closeListener An {@link Consumer} that is called when the anvil GUI is closed
-     * @return The {@link Builder} instance
-     * @throws IllegalArgumentException when the closeListener is null
+     * @param plugin           A {@link org.bukkit.plugin.java.JavaPlugin} instance
+     * @param player           The {@link Player} to open the inventory for
+     * @param text             What to have the text already set to
+     * @param preventClose     Whether to prevent the inventory from closing
+     * @param closeListener    A {@link Consumer} when the inventory closes
+     * @param completeFunction A {@link BiFunction} that is called when the player clicks the {@link Slot#OUTPUT} slot
      */
-    public Builder onClose(Consumer<Player> closeListener) {
-      Validate.notNull(closeListener, "closeListener cannot be null");
-      this.closeListener = closeListener;
-      return this;
+    private AnvilGUI(
+            Plugin plugin,
+            Player player,
+            String text,
+            ItemStack insert,
+            boolean preventClose,
+            Consumer<Player> closeListener,
+            BiFunction<Player, String, Response> completeFunction
+    ) {
+        this.plugin = plugin;
+        this.player = player;
+        this.text = text;
+        this.preventClose = preventClose;
+        this.closeListener = closeListener;
+        this.completeFunction = completeFunction;
+        this.insert = insert;
+        openInventory();
     }
 
     /**
-     * Handles the inventory output slot when it is clicked
-     *
-     * @param completeFunction An {@link BiFunction} that is called when the user clicks the output slot
-     * @return The {@link Builder} instance
-     * @throws IllegalArgumentException when the completeFunction is null
+     * Opens the anvil GUI
      */
-    public Builder onComplete(BiFunction<Player, String, Response> completeFunction) {
-      Validate.notNull(completeFunction, "Complete function cannot be null");
-      this.completeFunction = completeFunction;
-      return this;
+    private void openInventory() {
+        this.insert = Objects.isNull(insert) ? makeDefaultItemStack(text) : insert;
+
+        WRAPPER.handleInventoryCloseEvent(player);
+        WRAPPER.setActiveContainerDefault(player);
+
+        Bukkit.getPluginManager().registerEvents(listener, plugin);
+
+        final Object container = WRAPPER.newContainerAnvil(player);
+
+        inventory = WRAPPER.toBukkitInventory(container);
+        inventory.setItem(Slot.INPUT_LEFT, this.insert);
+
+        containerId = WRAPPER.getNextContainerId(player);
+        WRAPPER.sendPacketOpenWindow(player, containerId);
+        WRAPPER.setActiveContainer(player, container);
+        WRAPPER.setActiveContainerId(container, containerId);
+        WRAPPER.addActiveContainerSlotListener(container, player);
+        open = true;
     }
 
     /**
-     * Sets the plugin for the {@link AnvilGUI}
+     * Makes the default {@link ItemStack} when it has not been
+     * provided by the {@link AnvilGUI.Builder}.
      *
-     * @param plugin The {@link Plugin} this anvil GUI is associated with
-     * @return The {@link Builder} instance
-     * @throws IllegalArgumentException if the plugin is null
+     * @param text The default {@link String} that you want to inset.
+     * @return A default {@link ItemStack} to insert to the GUI.
      */
-    public Builder plugin(Plugin plugin) {
-      Validate.notNull(plugin, "Plugin cannot be null");
-      this.plugin = plugin;
-      return this;
+    private ItemStack makeDefaultItemStack(String text) {
+        final ItemStack paper = new ItemStack(Material.PAPER);
+        final ItemMeta paperMeta = paper.getItemMeta();
+        paperMeta.setDisplayName(text);
+        paper.setItemMeta(paperMeta);
+        return paper;
     }
 
     /**
-     * Sets the text that is to be displayed to the user
+     * Closes the inventory if it's open.
      *
-     * @param text The text that is to be displayed to the user
-     * @return The {@link Builder} instance
-     * @throws IllegalArgumentException if the text is null
+     * @throws IllegalArgumentException If the inventory isn't open
      */
-    public Builder text(String text) {
-      Validate.notNull(text, "Text cannot be null");
-      this.text = text;
-      return this;
+    public void closeInventory() {
+        Validate.isTrue(open, "You can't close an inventory that isn't open!");
+        open = false;
+
+        WRAPPER.handleInventoryCloseEvent(player);
+        WRAPPER.setActiveContainerDefault(player);
+        WRAPPER.sendPacketCloseWindow(player, containerId);
+
+        HandlerList.unregisterAll(listener);
+
+        if (closeListener != null) {
+            closeListener.accept(player);
+        }
     }
 
     /**
-     * Sets the ItemStack that will be inserted into the
-     * Anvil GUI.
+     * Returns the Bukkit inventory for this anvil gui
      *
-     * @param itemStack The {@link ItemStack} that will be displayed
-     * @return The {@link Builder} instance
-     * @throws IllegalArgumentException if the {@link ItemStack} is null
+     * @return the {@link Inventory} for this anvil gui
      */
-    public Builder itemStack(ItemStack itemStack) {
-      Validate.notNull(itemStack, "The ItemStack cannot be null");
-      this.itemStack = itemStack;
-      return this;
+    public Inventory getInventory() {
+        return inventory;
     }
 
     /**
-     * Creates the anvil GUI and opens it for the player
-     *
-     * @param player The {@link Player} the anvil GUI should open for
-     * @return The {@link AnvilGUI} instance from this builder
-     * @throws IllegalArgumentException when the onComplete function, plugin, or player is null
+     * Simply holds the listeners for the GUI
      */
-    public AnvilGUI open(Player player) {
-      Validate.notNull(plugin, "Plugin cannot be null");
-      Validate.notNull(completeFunction, "Complete function cannot be null");
-      Validate.notNull(player, "Player cannot be null");
-      return new AnvilGUI(plugin, player, text, itemStack, preventClose, closeListener, completeFunction);
-    }
-  }
+    private class ListenUp implements Listener {
 
-  /**
-   * Represents a response when the player clicks the output item in the anvil GUI
-   */
-  public static class Response {
+        @EventHandler
+        public void onInventoryClick(InventoryClickEvent event) {
+            if (event.getInventory().equals(inventory) && event.getRawSlot() < 3) {
+                event.setCancelled(true);
+                final Player clicker = (Player) event.getWhoClicked();
+                if (event.getRawSlot() == Slot.OUTPUT) {
+                    final ItemStack clicked = inventory.getItem(Slot.OUTPUT);
+                    if (clicked == null || clicked.getType() == Material.AIR) return;
 
-    /**
-     * The text that is to be displayed to the user
-     */
-    private final String text;
+                    final Response response = completeFunction.apply(clicker, clicked.hasItemMeta() ? clicked.getItemMeta().getDisplayName() : "");
+                    if (response.getText() != null) {
+                        final ItemMeta meta = clicked.getItemMeta();
+                        meta.setDisplayName(response.getText());
+                        clicked.setItemMeta(meta);
+                        inventory.setItem(Slot.INPUT_LEFT, clicked);
+                    } else {
+                        closeInventory();
+                    }
+                }
+            }
+        }
 
-    /**
-     * Creates a response to the user's input
-     *
-     * @param text The text that is to be displayed to the user, which can be null to close the inventory
-     */
-    private Response(String text) {
-      this.text = text;
-    }
+        @EventHandler
+        public void onInventoryClose(InventoryCloseEvent event) {
+            if (open && event.getInventory().equals(inventory)) {
+                closeInventory();
+                if (preventClose) {
+                    Bukkit.getScheduler().runTask(plugin, AnvilGUI.this::openInventory);
+                }
+            }
+        }
 
-    /**
-     * Gets the text that is to be displayed to the user
-     *
-     * @return The text that is to be displayed to the user
-     */
-    public String getText() {
-      return text;
     }
 
     /**
-     * Returns an {@link Response} object for when the anvil GUI is to close
-     *
-     * @return An {@link Response} object for when the anvil GUI is to close
+     * A builder class for an {@link AnvilGUI} object
      */
-    public static Response close() {
-      return new Response(null);
+    public static class Builder {
+
+        /**
+         * An {@link Consumer} that is called when the anvil GUI is closed
+         */
+        private Consumer<Player> closeListener;
+        /**
+         * A state that decides where the anvil GUI is able to be closed by the user
+         */
+        private boolean preventClose = false;
+        /**
+         * An {@link BiFunction} that is called when the anvil output slot has been clicked
+         */
+        private BiFunction<Player, String, Response> completeFunction;
+        /**
+         * The {@link Plugin} that this anvil GUI is associated with
+         */
+        private Plugin plugin;
+        /**
+         * The text that will be displayed to the user
+         */
+        private String text = "";
+        /**
+         * The {@link ItemStack} that would get inserted into the GUI.
+         */
+        private ItemStack itemStack;
+
+        /**
+         * Prevents the closing of the anvil GUI by the user
+         *
+         * @return The {@link Builder} instance
+         */
+        public Builder preventClose() {
+            preventClose = true;
+            return this;
+        }
+
+        /**
+         * Listens for when the inventory is closed
+         *
+         * @param closeListener An {@link Consumer} that is called when the anvil GUI is closed
+         * @return The {@link Builder} instance
+         * @throws IllegalArgumentException when the closeListener is null
+         */
+        public Builder onClose(Consumer<Player> closeListener) {
+            Validate.notNull(closeListener, "closeListener cannot be null");
+            this.closeListener = closeListener;
+            return this;
+        }
+
+        /**
+         * Handles the inventory output slot when it is clicked
+         *
+         * @param completeFunction An {@link BiFunction} that is called when the user clicks the output slot
+         * @return The {@link Builder} instance
+         * @throws IllegalArgumentException when the completeFunction is null
+         */
+        public Builder onComplete(BiFunction<Player, String, Response> completeFunction) {
+            Validate.notNull(completeFunction, "Complete function cannot be null");
+            this.completeFunction = completeFunction;
+            return this;
+        }
+
+        /**
+         * Sets the plugin for the {@link AnvilGUI}
+         *
+         * @param plugin The {@link Plugin} this anvil GUI is associated with
+         * @return The {@link Builder} instance
+         * @throws IllegalArgumentException if the plugin is null
+         */
+        public Builder plugin(Plugin plugin) {
+            Validate.notNull(plugin, "Plugin cannot be null");
+            this.plugin = plugin;
+            return this;
+        }
+
+        /**
+         * Sets the text that is to be displayed to the user
+         *
+         * @param text The text that is to be displayed to the user
+         * @return The {@link Builder} instance
+         * @throws IllegalArgumentException if the text is null
+         */
+        public Builder text(String text) {
+            Validate.notNull(text, "Text cannot be null");
+            this.text = text;
+            return this;
+        }
+
+        /**
+         * Sets the ItemStack that will be inserted into the
+         * Anvil GUI.
+         *
+         * @param itemStack The {@link ItemStack} that will be displayed
+         * @return The {@link Builder} instance
+         * @throws IllegalArgumentException if the {@link ItemStack} is null
+         */
+        public Builder itemStack(ItemStack itemStack) {
+            Validate.notNull(itemStack, "The ItemStack cannot be null");
+            this.itemStack = itemStack;
+            return this;
+        }
+
+        /**
+         * Creates the anvil GUI and opens it for the player
+         *
+         * @param player The {@link Player} the anvil GUI should open for
+         * @return The {@link AnvilGUI} instance from this builder
+         * @throws IllegalArgumentException when the onComplete function, plugin, or player is null
+         */
+        public AnvilGUI open(Player player) {
+            Validate.notNull(plugin, "Plugin cannot be null");
+            Validate.notNull(completeFunction, "Complete function cannot be null");
+            Validate.notNull(player, "Player cannot be null");
+            return new AnvilGUI(plugin, player, text, itemStack, preventClose, closeListener, completeFunction);
+        }
     }
 
     /**
-     * Returns an {@link Response} object for when the anvil GUI is to display text to the user
-     *
-     * @param text The text that is to be displayed to the user
-     * @return An {@link Response} object for when the anvil GUI is to display text to the user
+     * Represents a response when the player clicks the output item in the anvil GUI
      */
-    public static Response text(String text) {
-      return new Response(text);
+    public static class Response {
+
+        /**
+         * The text that is to be displayed to the user
+         */
+        private final String text;
+
+        /**
+         * Creates a response to the user's input
+         *
+         * @param text The text that is to be displayed to the user, which can be null to close the inventory
+         */
+        private Response(String text) {
+            this.text = text;
+        }
+
+        /**
+         * Gets the text that is to be displayed to the user
+         *
+         * @return The text that is to be displayed to the user
+         */
+        public String getText() {
+            return text;
+        }
+
+        /**
+         * Returns an {@link Response} object for when the anvil GUI is to close
+         *
+         * @return An {@link Response} object for when the anvil GUI is to close
+         */
+        public static Response close() {
+            return new Response(null);
+        }
+
+        /**
+         * Returns an {@link Response} object for when the anvil GUI is to display text to the user
+         *
+         * @param text The text that is to be displayed to the user
+         * @return An {@link Response} object for when the anvil GUI is to display text to the user
+         */
+        public static Response text(String text) {
+            return new Response(text);
+        }
+
     }
 
-  }
-
-  /**
-   * Class wrapping the magic constants of slot numbers in an anvil GUI
-   */
-  public static class Slot {
-
     /**
-     * The slot on the far left, where the first input is inserted. An {@link ItemStack} is always inserted
-     * here to be renamed
+     * Class wrapping the magic constants of slot numbers in an anvil GUI
      */
-    public static final int INPUT_LEFT = 0;
-    /**
-     * Not used, but in a real anvil you are able to put the second item you want to combine here
-     */
-    public static final int INPUT_RIGHT = 1;
-    /**
-     * The output slot, where an item is put when two items are combined from {@link #INPUT_LEFT} and
-     * {@link #INPUT_RIGHT} or {@link #INPUT_LEFT} is renamed
-     */
-    public static final int OUTPUT = 2;
+    public static class Slot {
 
-  }
+        /**
+         * The slot on the far left, where the first input is inserted. An {@link ItemStack} is always inserted
+         * here to be renamed
+         */
+        public static final int INPUT_LEFT = 0;
+        /**
+         * Not used, but in a real anvil you are able to put the second item you want to combine here
+         */
+        public static final int INPUT_RIGHT = 1;
+        /**
+         * The output slot, where an item is put when two items are combined from {@link #INPUT_LEFT} and
+         * {@link #INPUT_RIGHT} or {@link #INPUT_LEFT} is renamed
+         */
+        public static final int OUTPUT = 2;
+
+    }
 
 }

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -91,10 +91,10 @@ public class AnvilGUI {
      * @deprecated As of version 1.2.3, use {@link AnvilGUI.Builder}
      */
     @Deprecated
-    public AnvilGUI(Plugin plugin, Player holder, String inputMessage, ItemStack insert, BiFunction<Player, String, String> biFunction) {
-        this(plugin, holder, inputMessage, insert, false, null, (player, text) -> {
+    public AnvilGUI(Plugin plugin, Player holder, String insert, BiFunction<Player, String, String> biFunction) {
+        this(plugin, holder, insert,null, false, null, (player, text) -> {
             String response = biFunction.apply(player, text);
-            if (response != null) {
+            if(response != null) {
                 return Response.text(response);
             } else {
                 return Response.close();
@@ -105,18 +105,19 @@ public class AnvilGUI {
     /**
      * Create an AnvilGUI and open it for the player.
      *
-     * @param plugin           A {@link org.bukkit.plugin.java.JavaPlugin} instance
-     * @param player           The {@link Player} to open the inventory for
-     * @param text             What to have the text already set to
-     * @param preventClose     Whether to prevent the inventory from closing
-     * @param closeListener    A {@link Consumer} when the inventory closes
+     * @param plugin A {@link org.bukkit.plugin.java.JavaPlugin} instance
+     * @param player The {@link Player} to open the inventory for
+     * @param text What to have the text already set to
+     * @param itemStack The {@link ItemStack} that is going to be inserted in the GUI
+     * @param preventClose Whether to prevent the inventory from closing
+     * @param closeListener A {@link Consumer} when the inventory closes
      * @param completeFunction A {@link BiFunction} that is called when the player clicks the {@link Slot#OUTPUT} slot
      */
     private AnvilGUI(
             Plugin plugin,
             Player player,
             String text,
-            ItemStack insert,
+            ItemStack itemStack,
             boolean preventClose,
             Consumer<Player> closeListener,
             BiFunction<Player, String, Response> completeFunction
@@ -124,10 +125,10 @@ public class AnvilGUI {
         this.plugin = plugin;
         this.player = player;
         this.text = text;
+        this.insert = itemStack;
         this.preventClose = preventClose;
         this.closeListener = closeListener;
         this.completeFunction = completeFunction;
-        this.insert = insert;
         openInventory();
     }
 
@@ -185,14 +186,13 @@ public class AnvilGUI {
 
         HandlerList.unregisterAll(listener);
 
-        if (closeListener != null) {
+        if(closeListener != null) {
             closeListener.accept(player);
         }
     }
 
     /**
      * Returns the Bukkit inventory for this anvil gui
-     *
      * @return the {@link Inventory} for this anvil gui
      */
     public Inventory getInventory() {
@@ -214,7 +214,7 @@ public class AnvilGUI {
                     if (clicked == null || clicked.getType() == Material.AIR) return;
 
                     final Response response = completeFunction.apply(clicker, clicked.hasItemMeta() ? clicked.getItemMeta().getDisplayName() : "");
-                    if (response.getText() != null) {
+                    if(response.getText() != null) {
                         final ItemMeta meta = clicked.getItemMeta();
                         meta.setDisplayName(response.getText());
                         clicked.setItemMeta(meta);
@@ -230,7 +230,7 @@ public class AnvilGUI {
         public void onInventoryClose(InventoryCloseEvent event) {
             if (open && event.getInventory().equals(inventory)) {
                 closeInventory();
-                if (preventClose) {
+                if(preventClose) {
                     Bukkit.getScheduler().runTask(plugin, AnvilGUI.this::openInventory);
                 }
             }
@@ -270,7 +270,6 @@ public class AnvilGUI {
 
         /**
          * Prevents the closing of the anvil GUI by the user
-         *
          * @return The {@link Builder} instance
          */
         public Builder preventClose() {
@@ -280,7 +279,6 @@ public class AnvilGUI {
 
         /**
          * Listens for when the inventory is closed
-         *
          * @param closeListener An {@link Consumer} that is called when the anvil GUI is closed
          * @return The {@link Builder} instance
          * @throws IllegalArgumentException when the closeListener is null
@@ -293,7 +291,6 @@ public class AnvilGUI {
 
         /**
          * Handles the inventory output slot when it is clicked
-         *
          * @param completeFunction An {@link BiFunction} that is called when the user clicks the output slot
          * @return The {@link Builder} instance
          * @throws IllegalArgumentException when the completeFunction is null
@@ -306,7 +303,6 @@ public class AnvilGUI {
 
         /**
          * Sets the plugin for the {@link AnvilGUI}
-         *
          * @param plugin The {@link Plugin} this anvil GUI is associated with
          * @return The {@link Builder} instance
          * @throws IllegalArgumentException if the plugin is null
@@ -319,7 +315,6 @@ public class AnvilGUI {
 
         /**
          * Sets the text that is to be displayed to the user
-         *
          * @param text The text that is to be displayed to the user
          * @return The {@link Builder} instance
          * @throws IllegalArgumentException if the text is null
@@ -346,7 +341,6 @@ public class AnvilGUI {
 
         /**
          * Creates the anvil GUI and opens it for the player
-         *
          * @param player The {@link Player} the anvil GUI should open for
          * @return The {@link AnvilGUI} instance from this builder
          * @throws IllegalArgumentException when the onComplete function, plugin, or player is null
@@ -357,6 +351,7 @@ public class AnvilGUI {
             Validate.notNull(player, "Player cannot be null");
             return new AnvilGUI(plugin, player, text, itemStack, preventClose, closeListener, completeFunction);
         }
+
     }
 
     /**
@@ -371,7 +366,6 @@ public class AnvilGUI {
 
         /**
          * Creates a response to the user's input
-         *
          * @param text The text that is to be displayed to the user, which can be null to close the inventory
          */
         private Response(String text) {
@@ -380,7 +374,6 @@ public class AnvilGUI {
 
         /**
          * Gets the text that is to be displayed to the user
-         *
          * @return The text that is to be displayed to the user
          */
         public String getText() {
@@ -389,7 +382,6 @@ public class AnvilGUI {
 
         /**
          * Returns an {@link Response} object for when the anvil GUI is to close
-         *
          * @return An {@link Response} object for when the anvil GUI is to close
          */
         public static Response close() {
@@ -398,7 +390,6 @@ public class AnvilGUI {
 
         /**
          * Returns an {@link Response} object for when the anvil GUI is to display text to the user
-         *
          * @param text The text that is to be displayed to the user
          * @return An {@link Response} object for when the anvil GUI is to display text to the user
          */


### PR DESCRIPTION
Just add the ability to customize the item stack in the build pattern.
I've also made it so that if no `ItemStack` was provided, it'll just make a default `ItemStack`
```java
this.insert = Objects.isNull(insert) ? makeDefaultItemStack(text) : insert;
```

This was my desired build:
```java
new AnvilGUI.Builder().plugin(plugin).onClose(player -> cancel()).onComplete((player, res) -> {
        process(player, res);
        return AnvilGUI.Response.close();
      }).itemStack(item).open(this.sender);
```

P.S
I did my best to follow your coding conventions, and documented all of the new code that I wrote.
Also, I tend to auto format my code in IntelliJ, so sorry if you notice any difference when it comes to formatting.