### PR TITLE
Add ability to change item material and AnvilGUI-title in versions 1.14 and 1.15

### DIFF
--- a/1_10_R1/pom.xml
+++ b/1_10_R1/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.2.3-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/1_10_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_10_R1.java
+++ b/1_10_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_10_R1.java
@@ -33,7 +33,7 @@ public class Wrapper1_10_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId) {
+    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
         toNMS(player).playerConnection.sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
     }
 
@@ -89,7 +89,7 @@ public class Wrapper1_10_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player) {
+    public Object newContainerAnvil(Player player, String guiTitle) {
         return new Wrapper1_10_R1.AnvilContainer(toNMS(player));
     }
 

--- a/1_11_R1/pom.xml
+++ b/1_11_R1/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.2.3-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/1_11_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_11_R1.java
+++ b/1_11_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_11_R1.java
@@ -33,7 +33,7 @@ public class Wrapper1_11_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId) {
+    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
         toNMS(player).playerConnection.sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
     }
 
@@ -89,7 +89,7 @@ public class Wrapper1_11_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player) {
+    public Object newContainerAnvil(Player player, String guiTitle) {
         return new Wrapper1_11_R1.AnvilContainer(toNMS(player));
     }
 

--- a/1_12_R1/pom.xml
+++ b/1_12_R1/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.2.3-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/1_12_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_12_R1.java
+++ b/1_12_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_12_R1.java
@@ -33,7 +33,7 @@ public class Wrapper1_12_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId) {
+    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
         toNMS(player).playerConnection.sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
     }
 
@@ -89,7 +89,7 @@ public class Wrapper1_12_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player) {
+    public Object newContainerAnvil(Player player, String guiTitle) {
         return new Wrapper1_12_R1.AnvilContainer(toNMS(player));
     }
 

--- a/1_13_R1/pom.xml
+++ b/1_13_R1/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.2.3-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/1_13_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R1.java
+++ b/1_13_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R1.java
@@ -34,7 +34,7 @@ public class Wrapper1_13_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId) {
+    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
         toNMS(player).playerConnection.sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
     }
 
@@ -90,7 +90,7 @@ public class Wrapper1_13_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player) {
+    public Object newContainerAnvil(Player player, String guiTitle) {
         return new Wrapper1_13_R1.AnvilContainer(toNMS(player));
     }
 

--- a/1_13_R2/pom.xml
+++ b/1_13_R2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.2.3-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/1_13_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R2.java
+++ b/1_13_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R2.java
@@ -28,7 +28,7 @@ public class Wrapper1_13_R2 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId) {
+    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
         toNMS(player).playerConnection.sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
     }
 
@@ -84,7 +84,7 @@ public class Wrapper1_13_R2 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player) {
+    public Object newContainerAnvil(Player player, String guiTitle) {
         return new Wrapper1_13_R2.AnvilContainer(toNMS(player));
     }
 

--- a/1_14_4_R1/pom.xml
+++ b/1_14_4_R1/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>anvilgui-parent</artifactId>
         <groupId>net.wesjd</groupId>
-        <version>1.2.3-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <dependencies>

--- a/1_14_4_R1/src/main/java/net/wesjd/version/special/AnvilContainer1_14_4_R1.java
+++ b/1_14_4_R1/src/main/java/net/wesjd/version/special/AnvilContainer1_14_4_R1.java
@@ -10,11 +10,11 @@ import org.bukkit.entity.Player;
 
 public class AnvilContainer1_14_4_R1 extends ContainerAnvil {
 
-    public AnvilContainer1_14_4_R1(Player player, int containerId) {
+    public AnvilContainer1_14_4_R1(Player player, int containerId, String guiTitle) {
         super(containerId, ((CraftPlayer) player).getHandle().inventory,
                 ContainerAccess.at(((CraftWorld) player.getWorld()).getHandle(), new BlockPosition(0, 0, 0)));
         this.checkReachable = false;
-        setTitle(new ChatMessage("Repair & Name"));
+        setTitle(new ChatMessage(guiTitle));
     }
 
     @Override

--- a/1_14_R1/pom.xml
+++ b/1_14_R1/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.2.3-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <dependencies>
@@ -22,13 +22,13 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_14_4_R1</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/1_14_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_14_R1.java
+++ b/1_14_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_14_R1.java
@@ -41,8 +41,8 @@ public class Wrapper1_14_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId) {
-        toNMS(player).playerConnection.sendPacket(new PacketPlayOutOpenWindow(containerId, Containers.ANVIL, new ChatMessage("Repair & Name")));
+    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
+        toNMS(player).playerConnection.sendPacket(new PacketPlayOutOpenWindow(containerId, Containers.ANVIL, new ChatMessage(guiTitle)));
     }
 
     /**
@@ -97,11 +97,11 @@ public class Wrapper1_14_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player) {
+    public Object newContainerAnvil(Player player, String guiTitle) {
         if (IS_ONE_FOURTEEN) {
-            return new AnvilContainer1_14_4_R1(player, getRealNextContainerId(player));
+            return new AnvilContainer1_14_4_R1(player, getRealNextContainerId(player), guiTitle);
         } else {
-            return new Wrapper1_14_R1.AnvilContainer(player);
+            return new Wrapper1_14_R1.AnvilContainer(player, guiTitle);
         }
     }
 
@@ -120,11 +120,11 @@ public class Wrapper1_14_R1 implements VersionWrapper {
      */
     private class AnvilContainer extends ContainerAnvil {
 
-        public AnvilContainer(Player player) {
+        public AnvilContainer(Player player, String guiTitle) {
             super(getRealNextContainerId(player), ((CraftPlayer) player).getHandle().inventory,
                     ContainerAccess.at(((CraftWorld) player.getWorld()).getHandle(), new BlockPosition(0, 0, 0)));
             this.checkReachable = false;
-            setTitle(new ChatMessage("Repair & Name"));
+            setTitle(new ChatMessage(guiTitle));
         }
 
         @Override

--- a/1_15_R1/pom.xml
+++ b/1_15_R1/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.2.3-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/1_15_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_15_R1.java
+++ b/1_15_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_15_R1.java
@@ -32,8 +32,8 @@ public class Wrapper1_15_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId) {
-        toNMS(player).playerConnection.sendPacket(new PacketPlayOutOpenWindow(containerId, Containers.ANVIL, new ChatMessage("Repair & Name")));
+    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
+        toNMS(player).playerConnection.sendPacket(new PacketPlayOutOpenWindow(containerId, Containers.ANVIL, new ChatMessage(guiTitle)));
     }
 
     /**
@@ -88,8 +88,8 @@ public class Wrapper1_15_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player) {
-        return new AnvilContainer(player);
+    public Object newContainerAnvil(Player player, String guiTitle) {
+        return new AnvilContainer(player, guiTitle);
     }
 
     /**
@@ -107,11 +107,11 @@ public class Wrapper1_15_R1 implements VersionWrapper {
      */
     private class AnvilContainer extends ContainerAnvil {
 
-        public AnvilContainer(Player player) {
+        public AnvilContainer(Player player, String guiTitle) {
             super(getRealNextContainerId(player), ((CraftPlayer) player).getHandle().inventory,
                     ContainerAccess.at(((CraftWorld) player.getWorld()).getHandle(), new BlockPosition(0, 0, 0)));
             this.checkReachable = false;
-            setTitle(new ChatMessage("Repair & Name"));
+            setTitle(new ChatMessage(guiTitle));
         }
 
         @Override

--- a/1_8_R1/pom.xml
+++ b/1_8_R1/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.2.3-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/1_8_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R1.java
+++ b/1_8_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R1.java
@@ -33,7 +33,7 @@ public class Wrapper1_8_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId) {
+    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
         toNMS(player).playerConnection.sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
     }
 
@@ -89,7 +89,7 @@ public class Wrapper1_8_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player) {
+    public Object newContainerAnvil(Player player, String guiTitle) {
         return new AnvilContainer(toNMS(player));
     }
 

--- a/1_8_R2/pom.xml
+++ b/1_8_R2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.2.3-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/1_8_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R2.java
+++ b/1_8_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R2.java
@@ -33,7 +33,7 @@ public class Wrapper1_8_R2 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId) {
+    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
         toNMS(player).playerConnection.sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
     }
 
@@ -89,7 +89,7 @@ public class Wrapper1_8_R2 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player) {
+    public Object newContainerAnvil(Player player, String guiTitle) {
         return new AnvilContainer(toNMS(player));
     }
 

--- a/1_8_R3/pom.xml
+++ b/1_8_R3/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.2.3-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/1_8_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R3.java
+++ b/1_8_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R3.java
@@ -33,7 +33,7 @@ public class Wrapper1_8_R3 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId) {
+    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
         toNMS(player).playerConnection.sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
     }
 
@@ -89,7 +89,7 @@ public class Wrapper1_8_R3 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player) {
+    public Object newContainerAnvil(Player player, String guiTitle) {
         return new AnvilContainer(toNMS(player));
     }
 

--- a/1_9_R1/pom.xml
+++ b/1_9_R1/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.2.3-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/1_9_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R1.java
+++ b/1_9_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R1.java
@@ -33,7 +33,7 @@ public class Wrapper1_9_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId) {
+    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
         toNMS(player).playerConnection.sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
     }
 
@@ -89,7 +89,7 @@ public class Wrapper1_9_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player) {
+    public Object newContainerAnvil(Player player, String guiTitle) {
         return new AnvilContainer(toNMS(player));
     }
 

--- a/1_9_R2/pom.xml
+++ b/1_9_R2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.2.3-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/1_9_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R2.java
+++ b/1_9_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R2.java
@@ -33,7 +33,7 @@ public class Wrapper1_9_R2 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId) {
+    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
         toNMS(player).playerConnection.sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
     }
 
@@ -89,7 +89,7 @@ public class Wrapper1_9_R2 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player) {
+    public Object newContainerAnvil(Player player, String guiTitle) {
         return new AnvilContainer(toNMS(player));
     }
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ on the issues tab.
 ### In your plugin
 ```java
 new AnvilGUI.Builder()
-    .onClose(player -> {                   //called when the inventory is closing
+    .onClose(player -> {                      //called when the inventory is closing
         player.sendMessage("You closed the inventory.");
     })
-    .onComplete((player, text) -> {        //called when the inventory output slot is clicked
+    .onComplete((player, text) -> {           //called when the inventory output slot is clicked
         if(text.equalsIgnoreCase("you")) {
             player.sendMessage("You have magical powers!");
             return AnvilGUI.Response.close();
@@ -26,10 +26,12 @@ new AnvilGUI.Builder()
             return AnvilGUI.Response.text("Incorrect.");
         }
     })
-    .preventClose()                        //prevents the inventory from being closed
-    .text("What is the meaning of life?")  //sets the text the GUI should start with
-    .plugin(myPluginInstance)              //set the plugin instance
-    .open(myPlayer);                       //opens the GUI for the player provided
+    .preventClose()                           //prevents the inventory from being closed
+    .text("What is the meaning of life?")     //sets the text the GUI should start with
+    .item(new ItemStack(Material.GOLD_BLOCK)) //use a custom item for the first slot
+    .title("Enter your answer.")              //set the title of the GUI (only works in 1.14+)
+    .plugin(myPluginInstance)                 //set the plugin instance
+    .open(myPlayer);                          //opens the GUI for the player provided
 ```
 
 ### [Javadocs](http://docs.wesjd.net/AnvilGUI/)

--- a/abstraction/pom.xml
+++ b/abstraction/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.2.3-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <dependencies>

--- a/abstraction/src/main/java/net/wesjd/anvilgui/version/VersionWrapper.java
+++ b/abstraction/src/main/java/net/wesjd/anvilgui/version/VersionWrapper.java
@@ -25,9 +25,10 @@ public interface VersionWrapper {
     void handleInventoryCloseEvent(Player player);
 
     /**
-     * Sends PacketPlayOutOpenWindow to the player with the container id
+     * Sends PacketPlayOutOpenWindow to the player with the container id and window title
      * @param player The player to send the packet to
      * @param containerId The container id to open
+     * @param inventoryTitle The title of the inventory to be opened (only works in Minecraft 1.14 and above)
      */
     void sendPacketOpenWindow(Player player, int containerId, String inventoryTitle);
 
@@ -75,8 +76,9 @@ public interface VersionWrapper {
     /**
      * Creates a new ContainerAnvil
      * @param player The player to get the container of
+     * @param title The title of the anvil inventory
      * @return The Container instance
      */
-    Object newContainerAnvil(Player player, String anvilGuiTitle);
+    Object newContainerAnvil(Player player, String title);
 
 }

--- a/abstraction/src/main/java/net/wesjd/anvilgui/version/VersionWrapper.java
+++ b/abstraction/src/main/java/net/wesjd/anvilgui/version/VersionWrapper.java
@@ -29,7 +29,7 @@ public interface VersionWrapper {
      * @param player The player to send the packet to
      * @param containerId The container id to open
      */
-    void sendPacketOpenWindow(Player player, int containerId);
+    void sendPacketOpenWindow(Player player, int containerId, String inventoryTitle);
 
     /**
      * Sends PacketPlayOutCloseWindow to the player with the contaienr id
@@ -77,6 +77,6 @@ public interface VersionWrapper {
      * @param player The player to get the container of
      * @return The Container instance
      */
-    Object newContainerAnvil(Player player);
+    Object newContainerAnvil(Player player, String anvilGuiTitle);
 
 }

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.2.3-SNAPSHOT</version>
+        <version>1.3.0</version>
     </parent>
 
     <dependencies>
@@ -22,83 +22,83 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_8_R1</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_8_R2</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_8_R3</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_9_R1</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_9_R2</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_10_R1</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_11_R1</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_12_R1</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_13_R1</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_13_R2</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_14_R1</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_14_4_R1</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_15_R1</artifactId>
-            <version>1.2.3-SNAPSHOT</version>
+            <version>1.3.0</version>
         </dependency>
     </dependencies>
 

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -43,7 +43,7 @@ public class AnvilGUI {
 	/**
 	 * The title of the anvil inventory
 	 */
-	private String textGuiTitle;
+	private String inventoryTitle;
 	/**
 	 * The ItemStack that is in the {@link Slot#INPUT_LEFT} slot.
 	 */
@@ -125,7 +125,7 @@ public class AnvilGUI {
 	) {
 		this.plugin = plugin;
 		this.player = player;
-		this.textGuiTitle = inventoryTitle;
+		this.inventoryTitle = inventoryTitle;
 		this.insert = insert;
 		this.preventClose = preventClose;
 		this.closeListener = closeListener;
@@ -155,13 +155,13 @@ public class AnvilGUI {
 
 		Bukkit.getPluginManager().registerEvents(listener, plugin);
 
-		final Object container = WRAPPER.newContainerAnvil(player, textGuiTitle);
+		final Object container = WRAPPER.newContainerAnvil(player, inventoryTitle);
 
 		inventory = WRAPPER.toBukkitInventory(container);
 		inventory.setItem(Slot.INPUT_LEFT, this.insert);
 
 		containerId = WRAPPER.getNextContainerId(player, container);
-		WRAPPER.sendPacketOpenWindow(player, containerId, textGuiTitle);
+		WRAPPER.sendPacketOpenWindow(player, containerId, inventoryTitle);
 		WRAPPER.setActiveContainer(player, container);
 		WRAPPER.setActiveContainerId(container, containerId);
 		WRAPPER.addActiveContainerSlotListener(container, player);
@@ -260,7 +260,7 @@ public class AnvilGUI {
 		/**
 		 * The text that will be displayed to the user
 		 */
-		private String guiTitle = "Repair & Name";
+		private String title = "Repair & Name";
 		/**
 		 * The starting text on the item
 		 */
@@ -329,13 +329,13 @@ public class AnvilGUI {
 
 		/**
 		 * Sets the AnvilGUI title that is to be displayed to the user
-		 * @param guiTitle The guiTitle that is to be displayed to the user
+		 * @param title The title that is to be displayed to the user
 		 * @return The {@link Builder} instance
-		 * @throws IllegalArgumentException if the guiTitle is null
+		 * @throws IllegalArgumentException if the title is null
 		 */
-		public Builder guiTitle(String guiTitle) {
-			Validate.notNull(guiTitle, "ItemText cannot be null");
-			this.guiTitle = guiTitle;
+		public Builder title(String title) {
+			Validate.notNull(title, "title cannot be null");
+			this.title = title;
 			return this;
 		}
 
@@ -361,7 +361,7 @@ public class AnvilGUI {
 			Validate.notNull(plugin, "Plugin cannot be null");
 			Validate.notNull(completeFunction, "Complete function cannot be null");
 			Validate.notNull(player, "Player cannot be null");
-			return new AnvilGUI(plugin, player, guiTitle, itemText, item, preventClose, closeListener, completeFunction);
+			return new AnvilGUI(plugin, player, title, itemText, item, preventClose, closeListener, completeFunction);
 		}
 
 	}

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -43,7 +43,15 @@ public class AnvilGUI {
 	/**
 	 * The text that will be displayed to the user
 	 */
-	private String text = "";
+	private String textGuiTitle = "";
+	/**
+	 * The text that will be displayed to the user
+	 */
+	private String itemText;
+	/**
+	 * The text that will be displayed to the user
+	 */
+	private Material itemMaterial;
 	/**
 	 * A state that decides where the anvil GUI is able to be closed by the user
 	 */
@@ -91,7 +99,7 @@ public class AnvilGUI {
 	 */
 	@Deprecated
 	public AnvilGUI(Plugin plugin, Player holder, String insert, BiFunction<Player, String, String> biFunction) {
-		this(plugin, holder, insert, false, null, (player, text) -> {
+		this(plugin, holder, insert, "Repair & Name", Material.PAPER, false, null, (player, text) -> {
 			String response = biFunction.apply(player, text);
 			if(response != null) {
 				return Response.text(response);
@@ -106,7 +114,9 @@ public class AnvilGUI {
 	 *
 	 * @param plugin A {@link org.bukkit.plugin.java.JavaPlugin} instance
 	 * @param player The {@link Player} to open the inventory for
-	 * @param text What to have the text already set to
+	 * @param textGuiTitle What to have the text already set to
+	 * @param itemText The name of the item in the first slot of the anvilGui
+	 * @param itemMaterial The material of the item in the first slot of the anvilGUI
 	 * @param preventClose Whether to prevent the inventory from closing
 	 * @param closeListener A {@link Consumer} when the inventory closes
 	 * @param completeFunction A {@link BiFunction} that is called when the player clicks the {@link Slot#OUTPUT} slot
@@ -114,14 +124,18 @@ public class AnvilGUI {
 	private AnvilGUI(
 			Plugin plugin,
 			Player player,
-			String text,
+			String textGuiTitle,
+			String itemText,
+			Material itemMaterial,
 			boolean preventClose,
 			Consumer<Player> closeListener,
 			BiFunction<Player, String, Response> completeFunction
 	) {
 		this.plugin = plugin;
 		this.player = player;
-		this.text = text;
+		this.textGuiTitle = textGuiTitle;
+		this.itemText = itemText;
+		this.itemMaterial = itemMaterial;
 		this.preventClose = preventClose;
 		this.closeListener = closeListener;
 		this.completeFunction = completeFunction;
@@ -132,9 +146,9 @@ public class AnvilGUI {
 	 * Opens the anvil GUI
 	 */
 	private void openInventory() {
-		final ItemStack paper = new ItemStack(Material.PAPER);
+		final ItemStack paper = new ItemStack(itemMaterial);
 		final ItemMeta paperMeta = paper.getItemMeta();
-		paperMeta.setDisplayName(text);
+		paperMeta.setDisplayName(itemText);
 		paper.setItemMeta(paperMeta);
 		this.insert = paper;
 
@@ -143,13 +157,13 @@ public class AnvilGUI {
 
 		Bukkit.getPluginManager().registerEvents(listener, plugin);
 
-		final Object container = WRAPPER.newContainerAnvil(player);
+		final Object container = WRAPPER.newContainerAnvil(player, textGuiTitle);
 
 		inventory = WRAPPER.toBukkitInventory(container);
 		inventory.setItem(Slot.INPUT_LEFT, this.insert);
 
 		containerId = WRAPPER.getNextContainerId(player, container);
-		WRAPPER.sendPacketOpenWindow(player, containerId);
+		WRAPPER.sendPacketOpenWindow(player, containerId, textGuiTitle);
 		WRAPPER.setActiveContainer(player, container);
 		WRAPPER.setActiveContainerId(container, containerId);
 		WRAPPER.addActiveContainerSlotListener(container, player);
@@ -249,6 +263,14 @@ public class AnvilGUI {
 		 * The text that will be displayed to the user
 		 */
 		private String text = "";
+		/**
+		 * The starting text on the item
+		 */
+		private String itemText = "Repair & Name";
+		/**
+		 * The material of the item in the anvilGui
+		 */
+		private Material itemMaterial = Material.PAPER;
 
 		/**
 		 * Prevents the closing of the anvil GUI by the user
@@ -296,14 +318,38 @@ public class AnvilGUI {
 		}
 
 		/**
-		 * Sets the text that is to be displayed to the user
-		 * @param text The text that is to be displayed to the user
+		 * Sets the inital item-text that is displayed to the user
+		 * @param text The initial name of the item in the anvil
 		 * @return The {@link Builder} instance
 		 * @throws IllegalArgumentException if the text is null
 		 */
 		public Builder text(String text) {
 			Validate.notNull(text, "Text cannot be null");
-			this.text = text;
+			this.text = itemText;
+			return this;
+		}
+
+		/**
+		 * Sets the AnvilGUI title that is to be displayed to the user
+		 * @param guiTitle The guiTitle that is to be displayed to the user
+		 * @return The {@link Builder} instance
+		 * @throws IllegalArgumentException if the guiTitle is null
+		 */
+		public Builder guiTitke(String guiTitle) {
+			Validate.notNull(guiTitle, "ItemText cannot be null");
+			this.itemText = guiTitle;
+			return this;
+		}
+
+		/**
+		 * Sets the material of the item in the first slot of the anvil
+		 * @param material The material of the item in the first slot of the anvil
+		 * @return The {@link Builder} instance
+		 * @throws IllegalArgumentException if the material is null
+		 */
+		public Builder itemMaterial(Material material) {
+			Validate.notNull(material, "ItemText cannot be null");
+			this.itemMaterial = material;
 			return this;
 		}
 
@@ -317,7 +363,7 @@ public class AnvilGUI {
 			Validate.notNull(plugin, "Plugin cannot be null");
 			Validate.notNull(completeFunction, "Complete function cannot be null");
 			Validate.notNull(player, "Player cannot be null");
-			return new AnvilGUI(plugin, player, text, preventClose, closeListener, completeFunction);
+			return new AnvilGUI(plugin, player, text, itemText, itemMaterial, preventClose, closeListener, completeFunction);
 		}
 
 	}

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -41,7 +41,7 @@ public class AnvilGUI {
 	 */
 	private final Player player;
 	/**
-	 * The text that will be displayed to the user
+	 * The title of the anvil inventory
 	 */
 	private String textGuiTitle;
 	/**
@@ -49,7 +49,7 @@ public class AnvilGUI {
 	 */
 	private String itemText;
 	/**
-	 * The text that will be displayed to the user
+	 * The material of the input slot item
 	 */
 	private Material itemMaterial;
 	/**
@@ -348,7 +348,7 @@ public class AnvilGUI {
 		 * @throws IllegalArgumentException if the material is null
 		 */
 		public Builder itemMaterial(Material material) {
-			Validate.notNull(material, "ItemText cannot be null");
+			Validate.notNull(material, "material cannot be null");
 			this.itemMaterial = material;
 			return this;
 		}

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -112,6 +112,7 @@ public class AnvilGUI {
 	 * @param preventClose Whether to prevent the inventory from closing
 	 * @param closeListener A {@link Consumer} when the inventory closes
 	 * @param completeFunction A {@link BiFunction} that is called when the player clicks the {@link Slot#OUTPUT} slot
+	 * @throws IllegalStateException If both itemText and insert are supplied
 	 */
 	private AnvilGUI(
 			Plugin plugin,
@@ -356,6 +357,7 @@ public class AnvilGUI {
 		 * @param player The {@link Player} the anvil GUI should open for
 		 * @return The {@link AnvilGUI} instance from this builder
 		 * @throws IllegalArgumentException when the onComplete function, plugin, or player is null
+		 * @throws IllegalStateException If both text and item are supplied
 		 */
 		public AnvilGUI open(Player player) {
 			Validate.notNull(plugin, "Plugin cannot be null");

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -43,7 +43,7 @@ public class AnvilGUI {
 	/**
 	 * The text that will be displayed to the user
 	 */
-	private String textGuiTitle = "";
+	private String textGuiTitle;
 	/**
 	 * The text that will be displayed to the user
 	 */
@@ -99,7 +99,7 @@ public class AnvilGUI {
 	 */
 	@Deprecated
 	public AnvilGUI(Plugin plugin, Player holder, String insert, BiFunction<Player, String, String> biFunction) {
-		this(plugin, holder, insert, "Repair & Name", Material.PAPER, false, null, (player, text) -> {
+		this(plugin, holder, "Repair & Name", insert, Material.PAPER, false, null, (player, text) -> {
 			String response = biFunction.apply(player, text);
 			if(response != null) {
 				return Response.text(response);
@@ -146,8 +146,8 @@ public class AnvilGUI {
 	 * Opens the anvil GUI
 	 */
 	private void openInventory() {
-		final ItemStack paper = new ItemStack(itemMaterial);
-		final ItemMeta paperMeta = paper.getItemMeta();
+		ItemStack paper = new ItemStack(itemMaterial);
+		ItemMeta paperMeta = paper.getItemMeta();
 		paperMeta.setDisplayName(itemText);
 		paper.setItemMeta(paperMeta);
 		this.insert = paper;
@@ -262,11 +262,11 @@ public class AnvilGUI {
 		/**
 		 * The text that will be displayed to the user
 		 */
-		private String text = "";
+		private String guiTitle = "Repair & Name";
 		/**
 		 * The starting text on the item
 		 */
-		private String itemText = "Repair & Name";
+		private String itemText = "";
 		/**
 		 * The material of the item in the anvilGui
 		 */
@@ -325,7 +325,7 @@ public class AnvilGUI {
 		 */
 		public Builder text(String text) {
 			Validate.notNull(text, "Text cannot be null");
-			this.text = itemText;
+			this.itemText = text;
 			return this;
 		}
 
@@ -335,9 +335,9 @@ public class AnvilGUI {
 		 * @return The {@link Builder} instance
 		 * @throws IllegalArgumentException if the guiTitle is null
 		 */
-		public Builder guiTitke(String guiTitle) {
+		public Builder guiTitle(String guiTitle) {
 			Validate.notNull(guiTitle, "ItemText cannot be null");
-			this.itemText = guiTitle;
+			this.guiTitle = guiTitle;
 			return this;
 		}
 
@@ -363,7 +363,7 @@ public class AnvilGUI {
 			Validate.notNull(plugin, "Plugin cannot be null");
 			Validate.notNull(completeFunction, "Complete function cannot be null");
 			Validate.notNull(player, "Player cannot be null");
-			return new AnvilGUI(plugin, player, text, itemText, itemMaterial, preventClose, closeListener, completeFunction);
+			return new AnvilGUI(plugin, player, guiTitle, itemText, itemMaterial, preventClose, closeListener, completeFunction);
 		}
 
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.wesjd</groupId>
     <artifactId>anvilgui-parent</artifactId>
-    <version>1.2.3-SNAPSHOT</version>
+    <version>1.3.0</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
Hello @WesJD 

for one of my Spigot plugins I have extended the functionality of you wonderful AnvilGUI library.
As the title says I have added the possibility to change the Material of the ItemStrack in the first slot of the anvil. Additionally  I added a builder function to modify the title of the AnvilGUI-dialog.
While changing the GUI-title only works for Minecraft Versions 1.14.x and 1.15.x the change of the Item Material should work for all versions. 
The changes to the Builder-API are fully compatible to the versions before, so there should be not problems with users upgrading the library.

Thanks for reviewing this PR.
Kind regards,
mitras2