### PR TITLE
Prevent dragging of items into anvil slots

### DIFF
--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -11,6 +11,7 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -223,6 +224,18 @@ public class AnvilGUI {
 		}
 
 		@EventHandler
+		public void onInventoryDrag(InventoryDragEvent event) {
+			if (event.getInventory().equals(inventory)) {
+				for (int slot : Slot.values()) {
+					if (event.getRawSlots().contains(slot)) {
+						event.setCancelled(true);
+						break;
+					}
+				}
+			}
+		}
+
+		@EventHandler
 		public void onInventoryClose(InventoryCloseEvent event) {
 			if (open && event.getInventory().equals(inventory)) {
 				closeInventory();
@@ -414,6 +427,8 @@ public class AnvilGUI {
 	 */
 	public static class Slot {
 
+		private static final int[] values = new int[] {Slot.INPUT_LEFT, Slot.INPUT_RIGHT, Slot.OUTPUT};
+
 		/**
 		 * The slot on the far left, where the first input is inserted. An {@link ItemStack} is always inserted
 		 * here to be renamed
@@ -429,6 +444,13 @@ public class AnvilGUI {
 		 */
 		public static final int OUTPUT = 2;
 
+		/**
+		 * Get all anvil slot values
+		 * @return The array containing all possible anvil slots
+		 */
+		public static int[] values() {
+			return values;
+		}
 	}
 
 }


### PR DESCRIPTION
Currently it is possible to drag items into (or possible out of) anvil gui slots. This change checks which slot is contained in the drag event and cancels it if any of the anvil slots is dragged over.

Theoretically it would be possible to only remove items from the slots instead of allowing to drag over but doing that while keeping Vanilla behaviour [isn't trivial](https://github.com/Phoenix616/InventoryGui/blob/master/src/main/java/de/themoep/inventorygui/InventoryGui.java#L798-L843) due to the event not allowing to modify the resulting items directly.