### PR TITLE
Use snapshot in artifact name to properly auto update in dependencies

### DIFF
--- a/1_10_R1/pom.xml
+++ b/1_10_R1/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/1_11_R1/pom.xml
+++ b/1_11_R1/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/1_12_R1/pom.xml
+++ b/1_12_R1/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/1_13_R1/pom.xml
+++ b/1_13_R1/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/1_13_R2/pom.xml
+++ b/1_13_R2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/1_14_4_R1/pom.xml
+++ b/1_14_4_R1/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>anvilgui-parent</artifactId>
         <groupId>net.wesjd</groupId>
-        <version>1.3.0</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/1_14_R1/pom.xml
+++ b/1_14_R1/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -22,13 +22,13 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_14_4_R1</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/1_15_R1/pom.xml
+++ b/1_15_R1/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/1_16_R1/pom.xml
+++ b/1_16_R1/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/1_7_R4/pom.xml
+++ b/1_7_R4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>anvilgui-parent</artifactId>
         <groupId>net.wesjd</groupId>
-        <version>1.3.0</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/1_8_R1/pom.xml
+++ b/1_8_R1/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/1_8_R2/pom.xml
+++ b/1_8_R2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/1_8_R3/pom.xml
+++ b/1_8_R3/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/1_9_R1/pom.xml
+++ b/1_9_R1/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/1_9_R2/pom.xml
+++ b/1_9_R2/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/abstraction/pom.xml
+++ b/abstraction/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -22,94 +22,94 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-abstraction</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_7_R4</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_8_R1</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_8_R2</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_8_R3</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_9_R1</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_9_R2</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_10_R1</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_11_R1</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_12_R1</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_13_R1</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_13_R2</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_14_R1</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_14_4_R1</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_15_R1</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_16_R1</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.wesjd</groupId>
     <artifactId>anvilgui-parent</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
This changes the project version to include `-SNAPSHOT` which allows maven to properly notice that these should be updated on each build instead of always using the cached one once it was downloaded the first time. Also there aren't stable releases anyways and the version number doesn't really need to be changed on each commit so using `-SNAPSHOT` for that just makes sense.

Also I realize that the current main way of obtaining the artifact is through jitpack but that's not ideal imo. for multiple reasons (the major ones is that it just doesn't work half the time) and I have been adding this to my [own repo](https://repo.minebench.de) via my buildserver with the proper group and artifact ids and versioning. Ideally we would have a proper repo in the future again, even just [github packages](https://github.com/features/packages) would be an improvement to the current situation (but still not ideal as they require a github account and authentification with that).