### PR TITLE
Added GitHub Actions to replace unused Travis CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: Deploy to CodeMC
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Deploy Maven package
+        uses: samuelmeuli/action-maven-publish@v1
+        with:
+          maven_args: -B -ntp
+          server_id: codemc
+          nexus_username: ${{ secrets.CODEMC_USERNAME }}
+          nexus_password: ${{ secrets.CODEMC_PASSWORD }}
+      - name: Deploy GitHub Pages
+        if: success()
+        uses: crazy-max/ghaction-github-pages@v2
+        with:
+          target_branch: gh-pages
+          build_dir: api/javadoc
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,24 @@
+name: Pull-Request
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Verify
+        run: mvn install javadoc:javadoc -B -ntp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: java
-install: true
-script:
-  - mvn clean install -B -ntp

--- a/pom.xml
+++ b/pom.xml
@@ -86,11 +86,11 @@
 
     <distributionManagement>
         <repository>
-            <id>codemc-releases</id>
+            <id>codemc</id>
             <url>https://repo.codemc.io/repository/maven-releases/</url>
         </repository>
         <snapshotRepository>
-            <id>codemc-snapshots</id>
+            <id>codemc</id>
             <url>https://repo.codemc.io/repository/maven-snapshots/</url>
         </snapshotRepository>
     </distributionManagement>


### PR DESCRIPTION
`pull_request.yml`: GitHub-Action for Pull-Requests
The action tries to compile and create javadocs for the project, but does not publish it

`deploy.yml`: GitHub-Action for Deployments

This action will automatically publish the project to CodeMC repos and put the JavaDocs onto `gh-pages` branch

Notes:
- I had to rename the name of the CodeMC repos in the `pom.xml` to the same name for the action to work independently if it is a snapshot or not
- Currently, the `gh-pages` deployment will always force-push, but that can be changed
---
Optionally, the Deployment Action can also be configured to only deploy on a tag instead of every commit to master if desired