### PR TITLE
Remove itemText default initialization in order to allow custom display names on ItemStacks

### DIFF
--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -322,7 +322,7 @@ public class AnvilGUI {
         /**
          * The starting text on the item
          */
-        private String itemText = "";
+        private String itemText;
         /**
          * An {@link ItemStack} to be put in the left input slot
          */


### PR DESCRIPTION
At the moment, it is not possible to use a display name when passing a custom ItemStack for the leftItem input. In order to fix this issue I removed the default `itemText` initialization. I have not yet encountered any problems after I made this change.