### PR TITLE
Add: 1.17 Support

### DIFF
--- a/1_17_R1/pom.xml
+++ b/1_17_R1/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.wesjd</groupId>
+        <artifactId>anvilgui-parent</artifactId>
+        <version>1.5.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>anvilgui-1_17_R1</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>1.17-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.wesjd</groupId>
+            <artifactId>anvilgui-abstraction</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/1_17_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_17_R1.java
+++ b/1_17_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_17_R1.java
@@ -1,0 +1,143 @@
+package net.wesjd.anvilgui.version;
+
+import net.minecraft.core.BlockPosition;
+import net.minecraft.network.chat.ChatComponentText;
+import net.minecraft.network.chat.ChatMessage;
+import net.minecraft.network.protocol.game.PacketPlayOutCloseWindow;
+import net.minecraft.network.protocol.game.PacketPlayOutOpenWindow;
+import net.minecraft.server.level.EntityPlayer;
+import net.minecraft.world.IInventory;
+import net.minecraft.world.entity.player.EntityHuman;
+import net.minecraft.world.inventory.Container;
+import net.minecraft.world.inventory.ContainerAccess;
+import net.minecraft.world.inventory.ContainerAnvil;
+import net.minecraft.world.inventory.Containers;
+import org.bukkit.craftbukkit.v1_17_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_17_R1.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_17_R1.event.CraftEventFactory;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+
+public class Wrapper1_17_R1 implements VersionWrapper {
+    private int getRealNextContainerId(Player player) {
+        return toNMS(player).nextContainerCounter();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getNextContainerId(Player player, Object container) {
+        return ((AnvilContainer) container).getContainerId();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void handleInventoryCloseEvent(Player player) {
+        CraftEventFactory.handleInventoryCloseEvent(toNMS(player));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
+        toNMS(player).b.sendPacket(new PacketPlayOutOpenWindow(containerId, Containers.h, new ChatComponentText(guiTitle)));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void sendPacketCloseWindow(Player player, int containerId) {
+        toNMS(player).b.sendPacket(new PacketPlayOutCloseWindow(containerId));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setActiveContainerDefault(Player player) {
+        (toNMS(player)).bV = (Container)(toNMS(player)).bU;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setActiveContainer(Player player, Object container) {
+        (toNMS(player)).bV = (Container)container;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setActiveContainerId(Object container, int containerId) {
+        //noop
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addActiveContainerSlotListener(Object container, Player player) {
+        toNMS(player).initMenu((Container) container);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Inventory toBukkitInventory(Object container) {
+        return ((Container) container).getBukkitView().getTopInventory();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object newContainerAnvil(Player player, String guiTitle) {
+        return new AnvilContainer(player, guiTitle);
+    }
+
+    /**
+     * Turns a {@link Player} into an NMS one
+     *
+     * @param player The player to be converted
+     * @return the NMS EntityPlayer
+     */
+    private EntityPlayer toNMS(Player player) {
+        return ((CraftPlayer) player).getHandle();
+    }
+
+    /**
+     * Modifications to ContainerAnvil that makes it so you don't have to have xp to use this anvil
+     */
+    private class AnvilContainer extends ContainerAnvil {
+        public AnvilContainer(Player player, String guiTitle) {
+            super(Wrapper1_17_R1.this.getRealNextContainerId(player), ((CraftPlayer)player).getHandle().getInventory(),
+                    ContainerAccess.at(((CraftWorld)player.getWorld()).getHandle(), new BlockPosition(0, 0, 0)));
+            this.checkReachable = false;
+            setTitle(new ChatMessage(guiTitle));
+        }
+
+        @Override
+        public void i() {
+            super.i();
+            this.w.set(0);
+        }
+
+        @Override
+        public void b(EntityHuman player) {}
+
+        @Override
+        protected void a(EntityHuman player, IInventory container) {}
+
+        public int getContainerId() {
+            return this.j;
+        }
+    }
+}

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -127,6 +127,12 @@
             <version>${project.parent.version}</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>net.wesjd</groupId>
+            <artifactId>anvilgui-1_17_R1</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/api/src/main/java/net/wesjd/anvilgui/version/VersionMatcher.java
+++ b/api/src/main/java/net/wesjd/anvilgui/version/VersionMatcher.java
@@ -36,7 +36,8 @@ public class VersionMatcher {
             Wrapper1_15_R1.class,
             Wrapper1_16_R1.class,
             Wrapper1_16_R2.class,
-            Wrapper1_16_R3.class
+            Wrapper1_16_R3.class,
+            Wrapper1_17_R1.class
     );
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
         <module>1_16_R1</module>
         <module>1_16_R2</module>
         <module>1_16_R3</module>
+        <module>1_17_R1</module>
     </modules>
 
     <repositories>


### PR DESCRIPTION
This adds a 1.17 wrapper. ~~It uses the new Mojang mappings for Spigot and remaps them to the spigot mappings when packaging. The Mojang mappings for NMS in Spigot will probably become standard in >1.18.~~
~~I'm unsure about the pom.xml in the wrapper and it's plugins configuration for the `specialsource` plugin, but it seems to work on my local repository and my own plugin using AnvilGUI as a dependency. Please correct me if there's any issues there.~~
We decided to use the obfuscated spigot mappings for this Wrapper, as they don't require a special maven plugin to run.

Closes #141 