### PR TITLE
Support older versions of Java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.1</version>
                     <configuration>
-                        <source>16</source>
-                        <target>16</target>
+                        <source>1.8</source>
+                        <target>1.8</target>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
You'll still require Java 16 for MC 1.17. I've tested it on Java 8 and Java 16. The reason I changed this was that I need my plugin to work on MC versions from 1.14 to 1.17 but because you can't use Java 16 on 1.14, I got errors saying that it was compiled with a newer version of java.