### PR TITLE
Add note regarding required Maven Shade plugin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ to prevent conflicts with other plugins. Here is an example of how to relocate t
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>${shade.version}</version>
+            <version>${shade.version}</version> <!-- The version must be at least 3.3.0 -->
             <executions>
                 <execution>
                     <phase>package</phase>


### PR DESCRIPTION
Because Minecraft 1.18 requires Java 17 and we use Java 17 for the version wrapper, some people have difficulties building their plugins because they use outdated versions of the Maven Shade plugin.

I just noticed that the Maven Shade plugin actually now has a stable release supporting Java 17 (`3.3.0`), so this seems like a reasonable addition to the README.