### PR TITLE
add support for mc 1.19

### DIFF
--- a/1_19_R1/pom.xml
+++ b/1_19_R1/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.wesjd</groupId>
+        <artifactId>anvilgui-parent</artifactId>
+        <version>1.5.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>anvilgui-1_19_R1</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>1.19-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.wesjd</groupId>
+            <artifactId>anvilgui-abstraction</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/1_19_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_19_R1.java
+++ b/1_19_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_19_R1.java
@@ -1,0 +1,110 @@
+package net.wesjd.anvilgui.version;
+
+import net.minecraft.core.BlockPosition;
+import net.minecraft.network.chat.IChatBaseComponent;
+import net.minecraft.network.protocol.game.PacketPlayOutCloseWindow;
+import net.minecraft.network.protocol.game.PacketPlayOutOpenWindow;
+import net.minecraft.server.level.EntityPlayer;
+import net.minecraft.world.IInventory;
+import net.minecraft.world.entity.player.EntityHuman;
+import net.minecraft.world.inventory.Container;
+import net.minecraft.world.inventory.ContainerAccess;
+import net.minecraft.world.inventory.ContainerAnvil;
+import net.minecraft.world.inventory.Containers;
+import org.bukkit.craftbukkit.v1_19_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_19_R1.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_19_R1.event.CraftEventFactory;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+
+public final class Wrapper1_19_R1 implements VersionWrapper {
+    private int getRealNextContainerId(Player player) {
+        return toNMS(player).nextContainerCounter();
+    }
+
+    /**
+     * Turns a {@link Player} into an NMS one
+     *
+     * @param player The player to be converted
+     * @return the NMS EntityPlayer
+     */
+    private EntityPlayer toNMS(Player player) {
+        return ((CraftPlayer) player).getHandle();
+    }
+
+    @Override
+    public int getNextContainerId(Player player, Object container) {
+        return ((AnvilContainer) container).getContainerId();
+    }
+
+    @Override
+    public void handleInventoryCloseEvent(Player player) {
+        CraftEventFactory.handleInventoryCloseEvent(toNMS(player));
+    }
+
+    @Override
+    public void sendPacketOpenWindow(Player player, int containerId, String inventoryTitle) {
+        toNMS(player).b.a(new PacketPlayOutOpenWindow(containerId, Containers.h, IChatBaseComponent.a(inventoryTitle)));
+    }
+
+    @Override
+    public void sendPacketCloseWindow(Player player, int containerId) {
+        toNMS(player).b.a(new PacketPlayOutCloseWindow(containerId));
+    }
+
+    @Override
+    public void setActiveContainerDefault(Player player) {
+        toNMS(player).bU = toNMS(player).bT;
+    }
+
+    @Override
+    public void setActiveContainer(Player player, Object container) {
+        toNMS(player).bU = (Container) container;
+    }
+
+    @Override
+    public void setActiveContainerId(Object container, int containerId) {
+
+    }
+
+    @Override
+    public void addActiveContainerSlotListener(Object container, Player player) {
+        toNMS(player).a((Container) container);
+    }
+
+    @Override
+    public Inventory toBukkitInventory(Object container) {
+        return ((Container) container).getBukkitView().getTopInventory();
+    }
+
+    @Override
+    public Object newContainerAnvil(Player player, String title) {
+        return new AnvilContainer(player, getRealNextContainerId(player), title);
+    }
+
+    private static class AnvilContainer extends ContainerAnvil {
+        public AnvilContainer(Player player, int containerId, String guiTitle) {
+
+            super(containerId, ((CraftPlayer) player).getHandle().fB(),
+                    ContainerAccess.a(((CraftWorld) player.getWorld()).getHandle(), new BlockPosition(0, 0, 0)));
+            this.checkReachable = false;
+            setTitle(IChatBaseComponent.a(guiTitle));
+        }
+
+        @Override
+        public void l() {
+            super.l();
+            this.w.a(0);
+        }
+
+        @Override
+        public void b(EntityHuman player) {}
+
+        @Override
+        protected void a(EntityHuman player, IInventory container) {}
+
+        public int getContainerId() {
+            return this.j;
+        }
+    }
+}

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -151,6 +151,12 @@
             <version>${project.parent.version}</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>net.wesjd</groupId>
+            <artifactId>anvilgui-1_19_R1</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <module>1_17_1_R1</module>
         <module>1_18_R1</module>
         <module>1_18_R2</module>
+        <module>1_19_R1</module>
     </modules>
 
     <repositories>


### PR DESCRIPTION
Update for mc 1.19, only needed to update a few variable and method names + `ChatComponentText(text)` seems to be gone, so replaced it with `IChatBaseComponent.a(text)`.

I've tested it on 1.19, seems to be working (inventory title too).