### PR TITLE
Fix: NoSuchMethodError on 1.19.1

### DIFF
--- a/1_19_1_R1/pom.xml
+++ b/1_19_1_R1/pom.xml
@@ -10,19 +10,13 @@
         <version>1.5.3-SNAPSHOT</version>
     </parent>
 
-    <artifactId>anvilgui-1_19_R1</artifactId>
+    <artifactId>anvilgui-1_19_1_R1</artifactId>
 
     <dependencies>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
-            <version>1.19-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.wesjd</groupId>
-            <artifactId>anvilgui-1_19_1_R1</artifactId>
-            <version>${project.parent.version}</version>
+            <version>1.19.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/1_19_1_R1/src/main/java/net/wesjd/anvilgui/version/special/AnvilContainer1_19_1_R1.java
+++ b/1_19_1_R1/src/main/java/net/wesjd/anvilgui/version/special/AnvilContainer1_19_1_R1.java
@@ -1,0 +1,39 @@
+package net.wesjd.anvilgui.version.special;
+
+
+import net.minecraft.core.BlockPosition;
+import net.minecraft.network.chat.IChatBaseComponent;
+import net.minecraft.world.IInventory;
+import net.minecraft.world.entity.player.EntityHuman;
+import net.minecraft.world.inventory.ContainerAccess;
+import net.minecraft.world.inventory.ContainerAnvil;
+import org.bukkit.craftbukkit.v1_19_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_19_R1.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+public class AnvilContainer1_19_1_R1 extends ContainerAnvil {
+    public AnvilContainer1_19_1_R1(Player player, int containerId, String guiTitle) {
+        super(
+                containerId,
+                ((CraftPlayer) player).getHandle().fA(),
+                ContainerAccess.a(((CraftWorld) player.getWorld()).getHandle(), new BlockPosition(0, 0, 0)));
+        this.checkReachable = false;
+        setTitle(IChatBaseComponent.a(guiTitle));
+    }
+
+    @Override
+    public void l() {
+        super.l();
+        this.w.a(0);
+    }
+
+    @Override
+    public void b(EntityHuman player) {}
+
+    @Override
+    protected void a(EntityHuman player, IInventory container) {}
+
+    public int getContainerId() {
+        return this.j;
+    }
+}

--- a/1_19_R1/pom.xml
+++ b/1_19_R1/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
-            <version>1.19-R0.1-SNAPSHOT</version>
+            <version>1.19.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <module>1_18_R1</module>
         <module>1_18_R2</module>
         <module>1_19_R1</module>
+        <module>1_19_1_R1</module>
     </modules>
 
     <repositories>


### PR DESCRIPTION
Fixes #221.

1.19.1 is still on 1_19_R1, though the fB method of EntityPlayer has been remapped to fA, causing a NoSuchMethodException. I wrote a bit of Java reflection code to detect the correct method and have tested this to work on both 1.19 and 1.19.1 servers.