### PR TITLE
add onPrepare method

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,16 @@ builder.onComplete((player, text) -> {
         return AnvilGUI.Response.text("Incorrect.");   
     }                                                  
 });                                                    
-```                                                    
+```                           
+                         
+#### `onPrepare(BiConsumer<Player, String>)`
+Takes a `BiConsumer<Player, String>` argument that is called when a player changes the input field of the anvil, i.e. when typing or undoing characters.
+It uses the [PrepareAnvilEvent](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/event/inventory/PrepareAnvilEvent.html), so it will only have an effect on MC versions >= 1.9.
+```java
+builder.onPrepare((player, text) -> {
+	player.sendMessage("Current input: " + text);
+});
+```
 
 #### `preventClose()` 
 Tells the AnvilGUI to prevent the user from pressing escape to close the inventory.

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
-            <version>1.8-R0.1-SNAPSHOT</version>
+            <version>1.19-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -10,7 +10,6 @@ import net.wesjd.anvilgui.version.Wrapper1_7_R4;
 import net.wesjd.anvilgui.version.Wrapper1_8_R1;
 import net.wesjd.anvilgui.version.Wrapper1_8_R2;
 import net.wesjd.anvilgui.version.Wrapper1_8_R3;
-
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -246,31 +245,41 @@ public class AnvilGUI {
     public Inventory getInventory() {
         return inventory;
     }
-    
-	private void registerEvents() {
-		Bukkit.getPluginManager().registerEvents(listener, plugin);
 
-		// registering the AnvilPrepareEvent listener externally since this event is not
-		// available for MC 1.7 and 1.8.
-		if (!(WRAPPER.getClass() == Wrapper1_7_R4.class || WRAPPER.getClass() == Wrapper1_8_R1.class
-				|| WRAPPER.getClass() == Wrapper1_8_R2.class || WRAPPER.getClass() == Wrapper1_8_R3.class)) {
+    private void registerEvents() {
+        Bukkit.getPluginManager().registerEvents(listener, plugin);
 
-			Bukkit.getPluginManager().registerEvent(PrepareAnvilEvent.class, listener, EventPriority.NORMAL, new EventExecutor() {
-				@Override
-				public void execute(Listener listener, Event event) throws EventException {
-					PrepareAnvilEvent prepareEvent = (PrepareAnvilEvent) event;
+        // registering the AnvilPrepareEvent listener externally since this event is not
+        // available for MC 1.7 and 1.8.
+        if (!(WRAPPER.getClass() == Wrapper1_7_R4.class
+                || WRAPPER.getClass() == Wrapper1_8_R1.class
+                || WRAPPER.getClass() == Wrapper1_8_R2.class
+                || WRAPPER.getClass() == Wrapper1_8_R3.class)) {
 
-					if (prepareEvent.getInventory().equals(inventory)) {
-						Player player = (Player) prepareEvent.getView().getPlayer();
-						if (prepareListener != null) {
-							prepareListener.accept(player, prepareEvent.getInventory().getRenameText());
-						}
-					}
-				}
-			}, plugin);
-		}
-	}
+            Bukkit.getPluginManager()
+                    .registerEvent(
+                            PrepareAnvilEvent.class,
+                            listener,
+                            EventPriority.NORMAL,
+                            new EventExecutor() {
+                                @Override
+                                public void execute(Listener listener, Event event) throws EventException {
+                                    PrepareAnvilEvent prepareEvent = (PrepareAnvilEvent) event;
 
+                                    if (prepareEvent.getInventory().equals(inventory)) {
+                                        Player player =
+                                                (Player) prepareEvent.getView().getPlayer();
+                                        if (prepareListener != null) {
+                                            prepareListener.accept(
+                                                    player,
+                                                    prepareEvent.getInventory().getRenameText());
+                                        }
+                                    }
+                                }
+                            },
+                            plugin);
+        }
+    }
 
     /**
      * Simply holds the listeners for the GUI
@@ -429,16 +438,16 @@ public class AnvilGUI {
             this.inputRightClickListener = inputRightClickListener;
             return this;
         }
-        
+
         /**
          * Listens for changes in the input field of the anvil. Ineffective for MC versions 1.7.* and 1.8.*
-         * 
+         *
          * @param prepareListener An {@link BiConsumer} that is called when the string of the input field is changed
-         * @return The {@link Builder} instance 
+         * @return The {@link Builder} instance
          */
         public Builder onPrepare(BiConsumer<Player, String> prepareListener) {
-        	this.prepareListener = prepareListener;
-        	return this;
+            this.prepareListener = prepareListener;
+            return this;
         }
 
         /**


### PR DESCRIPTION
see #231.
Tested both on 1.8 and 1.19 with the new `onPrepare` function set, seems to work without causing any errors. I've registered the PrepareAnvilEvent using the `PluginManager#registerEvent` method, since it can't be in the same Listener class for mc < 1.9.