### PR TITLE
Replace `Response` with more versatile `ResponseAction` & implement `closeThenRun`

### DIFF
--- a/1_10_R1/pom.xml
+++ b/1_10_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.1-SNAPSHOT</version>
+        <version>1.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_10_R1</artifactId>

--- a/1_11_R1/pom.xml
+++ b/1_11_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.1-SNAPSHOT</version>
+        <version>1.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_11_R1</artifactId>

--- a/1_12_R1/pom.xml
+++ b/1_12_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.1-SNAPSHOT</version>
+        <version>1.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_12_R1</artifactId>

--- a/1_13_R1/pom.xml
+++ b/1_13_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.1-SNAPSHOT</version>
+        <version>1.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_13_R1</artifactId>

--- a/1_13_R2/pom.xml
+++ b/1_13_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.1-SNAPSHOT</version>
+        <version>1.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_13_R2</artifactId>

--- a/1_14_4_R1/pom.xml
+++ b/1_14_4_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>anvilgui-parent</artifactId>
         <groupId>net.wesjd</groupId>
-        <version>1.6.1-SNAPSHOT</version>
+        <version>1.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_14_4_R1</artifactId>

--- a/1_14_R1/pom.xml
+++ b/1_14_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.1-SNAPSHOT</version>
+        <version>1.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_14_R1</artifactId>

--- a/1_15_R1/pom.xml
+++ b/1_15_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.1-SNAPSHOT</version>
+        <version>1.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_15_R1</artifactId>

--- a/1_16_R1/pom.xml
+++ b/1_16_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.1-SNAPSHOT</version>
+        <version>1.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R1</artifactId>

--- a/1_16_R2/pom.xml
+++ b/1_16_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.1-SNAPSHOT</version>
+        <version>1.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R2</artifactId>

--- a/1_16_R3/pom.xml
+++ b/1_16_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.1-SNAPSHOT</version>
+        <version>1.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R3</artifactId>

--- a/1_17_1_R1/pom.xml
+++ b/1_17_1_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.1-SNAPSHOT</version>
+        <version>1.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_17_1_R1</artifactId>

--- a/1_17_R1/pom.xml
+++ b/1_17_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.1-SNAPSHOT</version>
+        <version>1.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_17_R1</artifactId>

--- a/1_18_R1/pom.xml
+++ b/1_18_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.1-SNAPSHOT</version>
+        <version>1.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_18_R1</artifactId>

--- a/1_18_R2/pom.xml
+++ b/1_18_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.1-SNAPSHOT</version>
+        <version>1.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_18_R2</artifactId>

--- a/1_19_1_R1/pom.xml
+++ b/1_19_1_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.1-SNAPSHOT</version>
+        <version>1.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_1_R1</artifactId>

--- a/1_19_R1/pom.xml
+++ b/1_19_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.1-SNAPSHOT</version>
+        <version>1.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R1</artifactId>

--- a/1_19_R2/pom.xml
+++ b/1_19_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.1-SNAPSHOT</version>
+        <version>1.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R2</artifactId>

--- a/1_7_R4/pom.xml
+++ b/1_7_R4/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.1-SNAPSHOT</version>
+        <version>1.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_7_R4</artifactId>

--- a/1_8_R1/pom.xml
+++ b/1_8_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.1-SNAPSHOT</version>
+        <version>1.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R1</artifactId>

--- a/1_8_R2/pom.xml
+++ b/1_8_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.1-SNAPSHOT</version>
+        <version>1.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R2</artifactId>

--- a/1_8_R3/pom.xml
+++ b/1_8_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.1-SNAPSHOT</version>
+        <version>1.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R3</artifactId>

--- a/1_9_R1/pom.xml
+++ b/1_9_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.1-SNAPSHOT</version>
+        <version>1.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_9_R1</artifactId>

--- a/1_9_R2/pom.xml
+++ b/1_9_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.1-SNAPSHOT</version>
+        <version>1.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_9_R2</artifactId>

--- a/README.md
+++ b/README.md
@@ -82,41 +82,31 @@ builder.onClose(player -> {
 });                                                 
 ``` 
 
-#### `onComplete(BiFunction<Player, String, AnvilGUI.Response>)`  
-Takes a `BiFunction<Player, String, AnvilGUI.Response>` argument. The BiFunction is called when a player clicks the output slot. 
-The supplied string is what the player has inputted in the renaming field of the anvil gui. You must return an AnvilGUI.Response,
-which can either be `close()`, `text(String)`, or `openInventory(Inventory)`. Returning `close()` will close the inventory; returning 
-`text(String)` will keep the inventory open and put the supplied String in the renaming field; returning `openInventory(Inventory)`
-will open the provided inventory, which is useful for when a user has finished their input in GUI menus.
+#### `onComplete(Function<AnvilGUI.Completion, AnvilGUI.Response>)`
+Takes a `Function<AnvilGUI.Completion, List<AnvilGUI.ResponseAction>>` as argument. The function is called when a player clicks the output slot.
+The supplied `Completion` contains the player who clicked, the inputted text, the left item, right item and the output. You must return a `List<AnvilGUI.ResponseAction>`,
+which could include:
+- Closing the inventory (`AnvilGUI.ResponseAction.close()`)
+- Replacing the input text (`AnvilGUI.ResponseAction.replaceInputText(String)`)
+- Opening another inventory (`AnvilGUI.ResponseAction.openInventory(Inventory)`)
+- Closing and then running generic code (`AnvilGUI.ResponseAction.closeThenRun(Runnable)`)
+
+The list of actions are ran in the order they are supplied.
 ```java                                                
-builder.onComplete((player, text) -> {                 
-    if(text.equalsIgnoreCase("you")) {                 
-        player.sendMessage("You have magical powers!");
-        return AnvilGUI.Response.close();              
+builder.onComplete((completion) -> {                 
+    if(completion.getText().equalsIgnoreCase("you")) {
+        completion.getPlayer().sendMessage("You have magical powers!");
+        return Arrays.asList(AnvilGUI.ResponseAction.close());              
     } else {                                           
-        return AnvilGUI.Response.text("Incorrect.");   
+        return Arrays.asList(AnvilGUI.ResponseAction.replaceInputText("Try again"));   
     }                                                  
 });                                                    
-```
-
-#### `onComplete(Function<AnvilGUI.Completion, AnvilGUI.Response>)`
-Takes a `Function<AnvilGUI.Completion, AnvilGUI.Response>` as argument. The completion is called when a player clicks the output slot.
-The supplied completion contains the player who clicked, the inputted text, the left item, right item and the output. You must return an AnvilGUI.Response,
-which can either be `close()`, `text(String)`, or `openInventory(Inventory)`. Returning `close()` will close the inventory; returning 
-`text(String)` will keep the inventory open and put the supplied String in the renaming field; returning `openInventory(Inventory)`
-will open the provided inventory, which is useful for when a user has finished their input in GUI menus.
-Useful for situations when dealing with an interactive anvil gui.
-```java
-builder.onComplete(completion -> {
-    player.sendMessage("Left is a item with the Type of " + completion.getLeft().getType());
-    return AnvilGUI.Response.close();
-});
 ```
 
 #### `interactableSlots(int... slots)`
 This allows or denies users to take / input items in the anvil slots that are provided. This feature is useful when you try to make a inputting system using an anvil gui.
 ```java
-builder.canBeInteractedWith(Slot.INPUT_LEFT, Slot.INPUT_RIGHT);
+builder.interactableSlots(Slot.INPUT_LEFT, Slot.INPUT_RIGHT);
 ```
 
 #### `preventClose()` 
@@ -193,12 +183,12 @@ new AnvilGUI.Builder()
     .onClose(player -> {                                               //called when the inventory is closing
         player.sendMessage("You closed the inventory.");
     })
-    .onComplete((player, text) -> {                                    //called when the inventory output slot is clicked
-        if(text.equalsIgnoreCase("you")) {
-            player.sendMessage("You have magical powers!");
-            return AnvilGUI.Response.close();
+    .onComplete((completion) -> {                                    //called when the inventory output slot is clicked
+        if(completion.getText().equalsIgnoreCase("you")) {
+            completion.getPlayer().sendMessage("You have magical powers!");
+            return Arrays.asList(AnvilGUI.ResponseAction.close());
         } else {
-            return AnvilGUI.Response.text("Incorrect.");
+            return Arrays.asList(AnvilGUI.ResponseAction.replaceInputText("Try again"));
         }
     })
     .preventClose()                                                    //prevents the inventory from being closed

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ AnvilGUI requires the usage of Maven or a Maven compatible build system.
 <dependency>
     <groupId>net.wesjd</groupId>
     <artifactId>anvilgui</artifactId>
-    <version>1.6.1-SNAPSHOT</version>
+    <version>1.6.2-SNAPSHOT</version>
 </dependency>
 
 <repository>

--- a/abstraction/pom.xml
+++ b/abstraction/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.1-SNAPSHOT</version>
+        <version>1.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-abstraction</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.1-SNAPSHOT</version>
+        <version>1.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui</artifactId>

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -604,15 +604,12 @@ public class AnvilGUI {
         }
 
         /**
-         * Close the AnvilGUI, then run the provided runnable.
-         * @param runnable The runnable to run after the inventory closes
-         * @return The {@link ResponseAction} to achieve closing and then running the runnable
+         * Run the provided runnable
+         * @param runnable The runnable to run
+         * @return The {@link ResponseAction} to achieve running the runnable
          */
-        static ResponseAction closeThenRun(Runnable runnable) {
-            return (anvilgui, player) -> {
-                anvilgui.closeInventory();
-                runnable.run();
-            };
+        static ResponseAction run(Runnable runnable) {
+            return (anvilgui, player) -> runnable.run();
         }
     }
 

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -430,7 +430,10 @@ public class AnvilGUI {
         /**
          * Handles the inventory output slot when it is clicked
          *
-         * @param completeFunction An {@link Function} that is called when the user clicks the output slot
+         * @param completeFunction An {@link Function} that is called when the user clicks the output slot. The
+         *                         {@link Completion} contains information about the current state of the anvil,
+         *                         and the response is a list of {@link ResponseAction} to execute in the order
+         *                         that they are supplied.
          * @return The {@link Builder} instance
          * @throws IllegalArgumentException when the completeFunction is null
          */

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -1,6 +1,7 @@
 package net.wesjd.anvilgui;
 
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -620,34 +621,33 @@ public class AnvilGUI {
     public static class Response {
         /**
          * Returns an {@link Response} object for when the anvil GUI is to close
-         *
-         * @return An {@link Response} object for when the anvil GUI is to close
+         * @return An {@link Response} object for when the anvil GUI is to display text to the user
          * @deprecated Since 1.6.2, use {@link ResponseAction#close()}
          */
-        public static ResponseAction close() {
-            return ResponseAction.close();
+        public static List<ResponseAction> close() {
+            return Arrays.asList(ResponseAction.close());
         }
 
         /**
          * Returns an {@link Response} object for when the anvil GUI is to display text to the user
          *
          * @param text The text that is to be displayed to the user
-         * @return An {@link Response} object for when the anvil GUI is to display text to the user
+         * @return A list containing the {@link ResponseAction} for legacy compat
          * @deprecated Since 1.6.2, use {@link ResponseAction#replaceInputText(String)}
          */
-        public static ResponseAction text(String text) {
-            return ResponseAction.replaceInputText(text);
+        public static List<ResponseAction> text(String text) {
+            return Arrays.asList(ResponseAction.replaceInputText(text));
         }
 
         /**
          * Returns an {@link Response} object for when the GUI should open the provided inventory
          *
          * @param inventory The inventory to open
-         * @return The {@link Response} to return
+         * @return A list containing the {@link ResponseAction} for legacy compat
          * @deprecated Since 1.6.2, use {@link ResponseAction#openInventory(Inventory)}
          */
-        public static ResponseAction openInventory(Inventory inventory) {
-            return ResponseAction.openInventory(inventory);
+        public static List<ResponseAction> openInventory(Inventory inventory) {
+            return Arrays.asList(ResponseAction.openInventory(inventory));
         }
     }
 

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -3,7 +3,9 @@ package net.wesjd.anvilgui;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -76,7 +78,7 @@ public class AnvilGUI {
     /**
      * An {@link Function} that is called when the {@link Slot#OUTPUT} slot has been clicked
      */
-    private final Function<Completion, Response> completeFunction;
+    private final Function<Completion, List<ResponseAction>> completeFunction;
 
     /**
      * An {@link Consumer} that is called when the {@link Slot#INPUT_LEFT} slot has been clicked
@@ -127,7 +129,7 @@ public class AnvilGUI {
             Consumer<Player> closeListener,
             Consumer<Player> inputLeftClickListener,
             Consumer<Player> inputRightClickListener,
-            Function<Completion, Response> completeFunction) {
+            Function<Completion, List<ResponseAction>> completeFunction) {
         this.plugin = plugin;
         this.player = player;
         this.inventoryTitle = inventoryTitle;
@@ -223,9 +225,9 @@ public class AnvilGUI {
                 return;
             }
 
+            final Player clicker = (Player) event.getWhoClicked();
             // prevent players from merging items from the anvil inventory
-            if (event.getClickedInventory().equals(player.getInventory())
-                    && event.getClick().equals(ClickType.DOUBLE_CLICK)) {
+            if (event.getClickedInventory().equals(clicker) && event.getClick().equals(ClickType.DOUBLE_CLICK)) {
                 event.setCancelled(true);
                 return;
             }
@@ -234,27 +236,18 @@ public class AnvilGUI {
                 final int slot = event.getRawSlot();
                 event.setCancelled(!interactableSlots.contains(slot));
 
-                final Player clicker = (Player) event.getWhoClicked();
                 if (event.getRawSlot() == Slot.OUTPUT) {
                     final ItemStack clicked = inventory.getItem(Slot.OUTPUT);
                     if (clicked == null || clicked.getType() == Material.AIR) return;
 
-                    final Response response = completeFunction.apply(new Completion(
+                    final List<ResponseAction> actions = completeFunction.apply(new Completion(
                             notNull(inventory.getItem(Slot.INPUT_LEFT)),
                             notNull(inventory.getItem(Slot.INPUT_RIGHT)),
                             notNull(inventory.getItem(Slot.OUTPUT)),
                             player,
                             clicked.hasItemMeta() ? clicked.getItemMeta().getDisplayName() : ""));
-
-                    if (response.getText() != null) {
-                        final ItemMeta meta = clicked.getItemMeta();
-                        meta.setDisplayName(response.getText());
-                        clicked.setItemMeta(meta);
-                        inventory.setItem(Slot.INPUT_LEFT, clicked);
-                    } else if (response.getInventoryToOpen() != null) {
-                        clicker.openInventory(response.getInventoryToOpen());
-                    } else {
-                        closeInventory();
+                    for (final ResponseAction action : actions) {
+                        action.accept(AnvilGUI.this, clicker);
                     }
                 } else if (event.getRawSlot() == Slot.INPUT_LEFT) {
                     if (inputLeftClickListener != null) {
@@ -331,7 +324,7 @@ public class AnvilGUI {
         /**
          * An {@link Function} that is called when the anvil output slot has been clicked
          */
-        private Function<Completion, Response> completeFunction;
+        private Function<Completion, List<ResponseAction>> completeFunction;
         /**
          * The {@link Plugin} that this anvil GUI is associated with
          */
@@ -424,8 +417,10 @@ public class AnvilGUI {
          * @param completeFunction An {@link BiFunction} that is called when the user clicks the output slot
          * @return The {@link Builder} instance
          * @throws IllegalArgumentException when the completeFunction is null
+         * @deprecated Since 1.6.2, use {@link #onComplete(Function)}
          */
-        public Builder onComplete(BiFunction<Player, String, Response> completeFunction) {
+        @Deprecated
+        public Builder onComplete(BiFunction<Player, String, List<ResponseAction>> completeFunction) {
             Validate.notNull(completeFunction, "Complete function cannot be null");
             this.completeFunction = completion -> completeFunction.apply(completion.player, completion.text);
             return this;
@@ -438,7 +433,7 @@ public class AnvilGUI {
          * @return The {@link Builder} instance
          * @throws IllegalArgumentException when the completeFunction is null
          */
-        public Builder onComplete(Function<Completion, Response> completeFunction) {
+        public Builder onComplete(Function<Completion, List<ResponseAction>> completeFunction) {
             Validate.notNull(completeFunction, "Complete function cannot be null");
             this.completeFunction = completeFunction;
             return this;
@@ -567,53 +562,70 @@ public class AnvilGUI {
         }
     }
 
+    /** An action to run in response to a player clicking the output slot in the GUI. This interface is public
+     * and permits you, the developer, to add additional response features easily to your custom AnvilGUIs. */
+    public interface ResponseAction extends BiConsumer<AnvilGUI, Player> {
+
+        /**
+         * Replace the input text box value with the provided text value
+         * @param text The text to write in the input box
+         * @return The {@link ResponseAction} to achieve the text replacement
+         */
+        static ResponseAction replaceInputText(String text) {
+            return (anvilgui, player) -> {
+                final ItemStack outputSlotItem =
+                        anvilgui.getInventory().getItem(Slot.OUTPUT).clone();
+                final ItemMeta meta = outputSlotItem.getItemMeta();
+                meta.setDisplayName(text);
+                outputSlotItem.setItemMeta(meta);
+                anvilgui.getInventory().setItem(Slot.INPUT_LEFT, outputSlotItem);
+            };
+        }
+
+        /**
+         * Open another inventory
+         * @param otherInventory The inventory to open
+         * @return The {@link ResponseAction} to achieve the inventory open
+         */
+        static ResponseAction openInventory(Inventory otherInventory) {
+            return (anvigui, player) -> player.openInventory(otherInventory);
+        }
+
+        /**
+         * Close the AnvilGUI
+         * @return The {@link ResponseAction} to achieve closing the AnvilGUI
+         */
+        static ResponseAction close() {
+            return (anvilgui, player) -> anvilgui.closeInventory();
+        }
+
+        /**
+         * Close the AnvilGUI, then run the provided runnable.
+         * @param runnable The runnable to run after the inventory closes
+         * @return The {@link ResponseAction} to achieve closing and then running the runnable
+         */
+        static ResponseAction closeThenRun(Runnable runnable) {
+            return (anvilgui, player) -> {
+                anvilgui.closeInventory();
+                runnable.run();
+            };
+        }
+    }
+
     /**
      * Represents a response when the player clicks the output item in the anvil GUI
+     * @deprecated Since 1.6.2, use {@link ResponseAction}
      */
+    @Deprecated
     public static class Response {
-
-        /**
-         * The text that is to be displayed to the user
-         */
-        private final String text;
-
-        private final Inventory openInventory;
-
-        /**
-         * Creates a response to the user's input
-         *
-         * @param text The text that is to be displayed to the user, which can be null to close the inventory
-         */
-        private Response(String text, Inventory openInventory) {
-            this.text = text;
-            this.openInventory = openInventory;
-        }
-
-        /**
-         * Gets the text that is to be displayed to the user
-         *
-         * @return The text that is to be displayed to the user
-         */
-        public String getText() {
-            return text;
-        }
-
-        /**
-         * Gets the inventory that should be opened
-         *
-         * @return The inventory that should be opened
-         */
-        public Inventory getInventoryToOpen() {
-            return openInventory;
-        }
-
         /**
          * Returns an {@link Response} object for when the anvil GUI is to close
          *
          * @return An {@link Response} object for when the anvil GUI is to close
+         * @deprecated Since 1.6.2, use {@link ResponseAction#close()}
          */
-        public static Response close() {
-            return new Response(null, null);
+        public static ResponseAction close() {
+            return ResponseAction.close();
         }
 
         /**
@@ -621,9 +633,10 @@ public class AnvilGUI {
          *
          * @param text The text that is to be displayed to the user
          * @return An {@link Response} object for when the anvil GUI is to display text to the user
+         * @deprecated Since 1.6.2, use {@link ResponseAction#replaceInputText(String)}
          */
-        public static Response text(String text) {
-            return new Response(text, null);
+        public static ResponseAction text(String text) {
+            return ResponseAction.replaceInputText(text);
         }
 
         /**
@@ -631,9 +644,10 @@ public class AnvilGUI {
          *
          * @param inventory The inventory to open
          * @return The {@link Response} to return
+         * @deprecated Since 1.6.2, use {@link ResponseAction#openInventory(Inventory)}
          */
-        public static Response openInventory(Inventory inventory) {
-            return new Response(null, inventory);
+        public static ResponseAction openInventory(Inventory inventory) {
+            return ResponseAction.openInventory(inventory);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.wesjd</groupId>
     <artifactId>anvilgui-parent</artifactId>
-    <version>1.6.1-SNAPSHOT</version>
+    <version>1.6.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
This PR deprecates the existing `Response` class for a more versatile solution: `ResponseAction`. The onComplete argument function now must return a `List<ResponseAction>`, making it so someone could complete multiple actions at once. This is especially helpful in the scenario presented in #238, where they could now do:
```java
onComplete(completion -> {
    // other code
    return List.of(
        AnvilGUI.ResponseAction.close(),
        AnvilGUI.ResponseAction.run(() -> completion.getPlayer().performCommand("openmyothergui"))
    );
});
```

Closes #238 