### PR TITLE
`StateSnapshot` and generic `onClick` handler

### DIFF
--- a/1_10_R1/pom.xml
+++ b/1_10_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_10_R1</artifactId>

--- a/1_11_R1/pom.xml
+++ b/1_11_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_11_R1</artifactId>

--- a/1_12_R1/pom.xml
+++ b/1_12_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_12_R1</artifactId>

--- a/1_13_R1/pom.xml
+++ b/1_13_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_13_R1</artifactId>

--- a/1_13_R2/pom.xml
+++ b/1_13_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_13_R2</artifactId>

--- a/1_14_4_R1/pom.xml
+++ b/1_14_4_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>anvilgui-parent</artifactId>
         <groupId>net.wesjd</groupId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_14_4_R1</artifactId>

--- a/1_14_R1/pom.xml
+++ b/1_14_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_14_R1</artifactId>

--- a/1_15_R1/pom.xml
+++ b/1_15_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_15_R1</artifactId>

--- a/1_16_R1/pom.xml
+++ b/1_16_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R1</artifactId>

--- a/1_16_R2/pom.xml
+++ b/1_16_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R2</artifactId>

--- a/1_16_R3/pom.xml
+++ b/1_16_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R3</artifactId>

--- a/1_17_1_R1/pom.xml
+++ b/1_17_1_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_17_1_R1</artifactId>

--- a/1_17_R1/pom.xml
+++ b/1_17_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_17_R1</artifactId>

--- a/1_18_R1/pom.xml
+++ b/1_18_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_18_R1</artifactId>

--- a/1_18_R2/pom.xml
+++ b/1_18_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_18_R2</artifactId>

--- a/1_19_1_R1/pom.xml
+++ b/1_19_1_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_1_R1</artifactId>

--- a/1_19_R1/pom.xml
+++ b/1_19_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R1</artifactId>

--- a/1_19_R2/pom.xml
+++ b/1_19_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R2</artifactId>

--- a/1_19_R3/pom.xml
+++ b/1_19_R3/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R3</artifactId>

--- a/1_7_R4/pom.xml
+++ b/1_7_R4/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_7_R4</artifactId>

--- a/1_8_R1/pom.xml
+++ b/1_8_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R1</artifactId>

--- a/1_8_R2/pom.xml
+++ b/1_8_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R2</artifactId>

--- a/1_8_R3/pom.xml
+++ b/1_8_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R3</artifactId>

--- a/1_9_R1/pom.xml
+++ b/1_9_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_9_R1</artifactId>

--- a/1_9_R2/pom.xml
+++ b/1_9_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_9_R2</artifactId>

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ new AnvilGUI.Builder()
         } else {
             return Arrays.asList(AnvilGUI.ResponseAction.replaceInputText("Try again"));
         }
-    });
+    })
     .preventClose()                                                    //prevents the inventory from being closed
     .interactableSlots(Slot.INPUT_RIGHT)                               //allow player to take out and replace the right input item
     .text("What is the meaning of life?")                              //sets the text the GUI should start with

--- a/README.md
+++ b/README.md
@@ -103,7 +103,10 @@ builder.onClick((slot, stateSnapshot) -> {
     
     if(stateSnapshot.getText().equalsIgnoreCase("you")) {
         stateSnapshot.getPlayer().sendMessage("You have magical powers!");
-        return Arrays.asList(AnvilGUI.ResponseAction.close());              
+        return Arrays.asList(
+            AnvilGUI.ResponseAction.close(),
+            AnvilGUI.ResponseAction.run(() -> myCode(stateSnapshot.getPlayer()))
+        );              
     } else {                                           
         return Arrays.asList(AnvilGUI.ResponseAction.replaceInputText("Try again"));   
     }                                                  

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ AnvilGUI requires the usage of Maven or a Maven compatible build system.
 <dependency>
     <groupId>net.wesjd</groupId>
     <artifactId>anvilgui</artifactId>
-    <version>1.6.3-SNAPSHOT</version>
+    <version>1.6.4-SNAPSHOT</version>
 </dependency>
 
 <repository>

--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ which could include:
 
 The list of actions are ran in the order they are supplied.
 ```java                                                
-builder.onComplete((completion) -> {                 
-    if(completion.getText().equalsIgnoreCase("you")) {
-        completion.getPlayer().sendMessage("You have magical powers!");
+builder.onComplete((stateSnapshot) -> {                 
+    if(stateSnapshot.getText().equalsIgnoreCase("you")) {
+        stateSnapshot.getPlayer().sendMessage("You have magical powers!");
         return Arrays.asList(AnvilGUI.ResponseAction.close());              
     } else {                                           
         return Arrays.asList(AnvilGUI.ResponseAction.replaceInputText("Try again"));   
@@ -185,9 +185,9 @@ new AnvilGUI.Builder()
     .onClose(player -> {                                               //called when the inventory is closing
         player.sendMessage("You closed the inventory.");
     })
-    .onComplete((completion) -> {                                    //called when the inventory output slot is clicked
-        if(completion.getText().equalsIgnoreCase("you")) {
-            completion.getPlayer().sendMessage("You have magical powers!");
+    .onComplete((stateSnapshot) -> {                                    //called when the inventory output slot is clicked
+        if(stateSnapshot.getText().equalsIgnoreCase("you")) {
+            stateSnapshot.getPlayer().sendMessage("You have magical powers!");
             return Arrays.asList(AnvilGUI.ResponseAction.close());
         } else {
             return Arrays.asList(AnvilGUI.ResponseAction.replaceInputText("Try again"));

--- a/README.md
+++ b/README.md
@@ -76,26 +76,31 @@ ensure that your `<filters>` section contains the example `<filter>` as seen abo
 The `AnvilGUI.Builder` class is how you build an AnvilGUI. 
 The following methods allow you to modify various parts of the displayed GUI. Javadocs are available [here](http://docs.wesjd.net/AnvilGUI/).
 
-#### `onClose(Consumer<Player>)` 
-Takes a `Consumer<Player>` argument that is called when a player closes the anvil gui.
+#### `onClose(Consumer<StateSnapshot>)` 
+Takes a `Consumer<StateSnapshot>` argument that is called when a player closes the anvil gui.
 ```java                                             
-builder.onClose(player -> {                         
-    player.sendMessage("You closed the inventory.");
+builder.onClose(stateSnapshot -> {                         
+    stateSnapshot.getPlayer().sendMessage("You closed the inventory.");
 });                                                 
 ``` 
 
-#### `onComplete(Function<AnvilGUI.Completion, AnvilGUI.Response>)`
-Takes a `Function<AnvilGUI.Completion, List<AnvilGUI.ResponseAction>>` as argument. The function is called when a player clicks the output slot.
-The supplied `Completion` contains the player who clicked, the inputted text, the left item, right item and the output. You must return a `List<AnvilGUI.ResponseAction>`,
-which could include:
+#### `onClick(BiFunction<Integer, AnvilGUI.StateSnapshot, AnvilGUI.Response>)`
+Takes a `BiFunction` with the slot that was clicked and a snapshot of the current gui state. 
+The function is called when a player clicks any slots in the inventory.
+You must return a `List<AnvilGUI.ResponseAction>`, which could include:
 - Closing the inventory (`AnvilGUI.ResponseAction.close()`)
 - Replacing the input text (`AnvilGUI.ResponseAction.replaceInputText(String)`)
 - Opening another inventory (`AnvilGUI.ResponseAction.openInventory(Inventory)`)
 - Running generic code (`AnvilGUI.ResponseAction.run(Runnable)`)
+- Nothing! (`Collections.emptyList()`)
 
 The list of actions are ran in the order they are supplied.
 ```java                                                
-builder.onComplete((stateSnapshot) -> {                 
+builder.onClick((slot, stateSnapshot) -> {
+    if(slot != AnvilGUI.Slot.OUTPUT) {
+        return Collections.emptyList();
+    }   
+    
     if(stateSnapshot.getText().equalsIgnoreCase("you")) {
         stateSnapshot.getPlayer().sendMessage("You have magical powers!");
         return Arrays.asList(AnvilGUI.ResponseAction.close());              
@@ -120,6 +125,8 @@ builder.preventClose();
      
 #### `text(String)`
 Takes a `String` that contains what the initial text in the renaming field should be set to.
+If `itemLeft` is provided, then the display name is set to the provided text. If no `itemLeft`
+is set, then a piece of paper will be used.
 ```java                                           
 builder.text("What is the meaning of life?");     
 ```  
@@ -134,14 +141,6 @@ stack.setItemMeta(meta);
 builder.itemLeft(stack);        
 ```         
 
-#### `onLeftInputClick(Consumer<Player>)`
-Takes a `Consumer<Player>` to be executed when the item in the left input slot is clicked.
-```java                                              
-builder.onLeftInputClick(player -> {
-    player.sendMessage("You clicked the left input slot!");
-});        
-```      
-
 #### `itemRight(ItemStack)`
 Takes a custom `ItemStack` to be placed in the right input slot.
 ```java                                              
@@ -151,14 +150,6 @@ meta.setLore(Arrays.asList("A piece of metal"));
 stack.setItemMeta(meta); 
 builder.itemRight(stack);        
 ```         
-
-#### `onRightInputClick(Consumer<Player>)`
-Takes a `Consumer<Player>` to be executed when the item in the right input slot is clicked.
-```java                                              
-builder.onRightInputClick(player -> {
-    player.sendMessage("You clicked the right input slot!");
-});        
-```
 
 #### `title(String)`
 Takes a `String` that will be used as the inventory title. Only displayed in Minecraft 1.14 and above.
@@ -182,24 +173,26 @@ builder.open(player);
 ### A full example combining all methods
 ```java
 new AnvilGUI.Builder()
-    .onClose(player -> {                                               //called when the inventory is closing
-        player.sendMessage("You closed the inventory.");
+    .onClose(stateSnapshot -> {
+        stateSnapshot.getPlayer().sendMessage("You closed the inventory.");
     })
-    .onComplete((stateSnapshot) -> {                                    //called when the inventory output slot is clicked
+    .onClick((slot, stateSnapshot) -> {
+        if(slot != AnvilGUI.Slot.OUTPUT) {
+            return Collections.emptyList();
+        }
+
         if(stateSnapshot.getText().equalsIgnoreCase("you")) {
             stateSnapshot.getPlayer().sendMessage("You have magical powers!");
             return Arrays.asList(AnvilGUI.ResponseAction.close());
         } else {
             return Arrays.asList(AnvilGUI.ResponseAction.replaceInputText("Try again"));
         }
-    })
+    });
     .preventClose()                                                    //prevents the inventory from being closed
     .interactableSlots(Slot.INPUT_RIGHT)                               //allow player to take out and replace the right input item
     .text("What is the meaning of life?")                              //sets the text the GUI should start with
     .itemLeft(new ItemStack(Material.IRON_SWORD))                      //use a custom item for the first slot
     .itemRight(new ItemStack(Material.IRON_SWORD))                     //use a custom item for the second slot
-    .onLeftInputClick(player -> player.sendMessage("first sword"))     //called when the left input slot is clicked
-    .onRightInputClick(player -> player.sendMessage("second sword"))   //called when the right input slot is clicked
     .title("Enter your answer.")                                       //set the title of the GUI (only works in 1.14+)
     .plugin(myPluginInstance)                                          //set the plugin instance
     .open(myPlayer);                                                   //opens the GUI for the player provided

--- a/abstraction/pom.xml
+++ b/abstraction/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-abstraction</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.3-SNAPSHOT</version>
+        <version>1.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui</artifactId>

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -385,19 +385,6 @@ public class AnvilGUI {
          * @param item The {@link ItemStack} to be put in the first slot
          * @return The {@link Builder} instance
          * @throws IllegalArgumentException if the {@link ItemStack} is null
-         * @deprecated As of version 1.4.0, use {@link AnvilGUI.Builder#itemLeft}
-         */
-        @Deprecated
-        public Builder item(ItemStack item) {
-            return itemLeft(item);
-        }
-
-        /**
-         * Sets the {@link ItemStack} to be put in the first slot
-         *
-         * @param item The {@link ItemStack} to be put in the first slot
-         * @return The {@link Builder} instance
-         * @throws IllegalArgumentException if the {@link ItemStack} is null
          */
         public Builder itemLeft(ItemStack item) {
             Validate.notNull(item, "item cannot be null");

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -83,7 +83,7 @@ public class AnvilGUI {
 
     /** An {@link Consumer} that is called when the anvil GUI is close */
     private final Consumer<StateSnapshot> closeListener;
-    /** An {@link BiFunction} that is called when the {@link Slot#OUTPUT} slot has been clicked */
+    /** An {@link BiFunction} that is called when a slot is clicked */
     private final BiFunction<Integer, StateSnapshot, List<ResponseAction>> clickHandler;
 
     /**

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -229,7 +229,8 @@ public class AnvilGUI {
             final int rawSlot = event.getRawSlot();
             if (rawSlot < 3 || event.getAction().equals(InventoryAction.MOVE_TO_OTHER_INVENTORY)) {
                 event.setCancelled(!interactableSlots.contains(rawSlot));
-                final List<ResponseAction> actions = clickHandler.apply(rawSlot, StateSnapshot.fromAnvilGUI(AnvilGUI.this));
+                final List<ResponseAction> actions =
+                        clickHandler.apply(rawSlot, StateSnapshot.fromAnvilGUI(AnvilGUI.this));
                 for (final ResponseAction action : actions) {
                     action.accept(AnvilGUI.this, clicker);
                 }
@@ -258,7 +259,6 @@ public class AnvilGUI {
             }
         }
     }
-
 
     /** A builder class for an {@link AnvilGUI} object */
     public static class Builder {

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -110,7 +110,7 @@ public class AnvilGUI {
     private boolean open;
 
     /**
-     * Create an AnvilGUI and open it for the player.
+     * Create an AnvilGUI
      *
      * @param plugin           A {@link org.bukkit.plugin.java.JavaPlugin} instance
      * @param player           The {@link Player} to open the inventory for
@@ -141,8 +141,6 @@ public class AnvilGUI {
         this.inputLeftClickListener = inputLeftClickListener;
         this.inputRightClickListener = inputRightClickListener;
         this.completeFunction = completeFunction;
-
-        openInventory();
     }
 
     /**
@@ -555,7 +553,7 @@ public class AnvilGUI {
                 itemLeft.setItemMeta(paperMeta);
             }
 
-            return new AnvilGUI(
+            final AnvilGUI anvilGUI = new AnvilGUI(
                     plugin,
                     player,
                     title,
@@ -566,6 +564,8 @@ public class AnvilGUI {
                     inputLeftClickListener,
                     inputRightClickListener,
                     completeFunction);
+            anvilGUI.openInventory();
+            return anvilGUI;
         }
     }
 

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -578,9 +578,9 @@ public class AnvilGUI {
         private static StateSnapshot fromAnvilGUI(AnvilGUI anvilGUI) {
             final Inventory inventory = anvilGUI.getInventory();
             return new StateSnapshot(
-                    itemNotNull(inventory.getItem(Slot.INPUT_LEFT).clone()),
-                    itemNotNull(inventory.getItem(Slot.INPUT_RIGHT).clone()),
-                    itemNotNull(inventory.getItem(Slot.OUTPUT).clone()),
+                    itemNotNull(inventory.getItem(Slot.INPUT_LEFT)).clone(),
+                    itemNotNull(inventory.getItem(Slot.INPUT_RIGHT)).clone(),
+                    itemNotNull(inventory.getItem(Slot.OUTPUT)).clone(),
                     anvilGUI.player);
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.wesjd</groupId>
     <artifactId>anvilgui-parent</artifactId>
-    <version>1.6.3-SNAPSHOT</version>
+    <version>1.6.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
This PR firstly closes #246, which means converting `AnvilGUI.Completion` to `AnvilGUI.StateSnapshot` and including `StateSnapshot` in the `onClose` listener.

Secondly, it creates a generic `onClick` handler which seeks to replace `onComplete`, `onLeftInputClick`, and `onRightInputClick`. Seeing the need in #246 to have the anvils state on close, it will certainly be needed in other scenarios. This change requires a bit more of an explicit check for the slot you want to detect, but is more versatile in the long run and should support all use cases of this library correctly. 