### PR TITLE
Enable Folia support and add async click handler

### DIFF
--- a/1_10_R1/pom.xml
+++ b/1_10_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.4-SNAPSHOT</version>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_10_R1</artifactId>

--- a/1_11_R1/pom.xml
+++ b/1_11_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.4-SNAPSHOT</version>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_11_R1</artifactId>

--- a/1_12_R1/pom.xml
+++ b/1_12_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.4-SNAPSHOT</version>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_12_R1</artifactId>

--- a/1_13_R1/pom.xml
+++ b/1_13_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.4-SNAPSHOT</version>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_13_R1</artifactId>

--- a/1_13_R2/pom.xml
+++ b/1_13_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.4-SNAPSHOT</version>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_13_R2</artifactId>

--- a/1_14_4_R1/pom.xml
+++ b/1_14_4_R1/pom.xml
@@ -5,9 +5,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>anvilgui-parent</artifactId>
         <groupId>net.wesjd</groupId>
-        <version>1.6.4-SNAPSHOT</version>
+        <artifactId>anvilgui-parent</artifactId>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_14_4_R1</artifactId>

--- a/1_14_R1/pom.xml
+++ b/1_14_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.4-SNAPSHOT</version>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_14_R1</artifactId>

--- a/1_15_R1/pom.xml
+++ b/1_15_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.4-SNAPSHOT</version>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_15_R1</artifactId>

--- a/1_16_R1/pom.xml
+++ b/1_16_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.4-SNAPSHOT</version>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R1</artifactId>

--- a/1_16_R2/pom.xml
+++ b/1_16_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.4-SNAPSHOT</version>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R2</artifactId>

--- a/1_16_R3/pom.xml
+++ b/1_16_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.4-SNAPSHOT</version>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R3</artifactId>

--- a/1_17_1_R1/pom.xml
+++ b/1_17_1_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.4-SNAPSHOT</version>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_17_1_R1</artifactId>

--- a/1_17_R1/pom.xml
+++ b/1_17_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.4-SNAPSHOT</version>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_17_R1</artifactId>

--- a/1_18_R1/pom.xml
+++ b/1_18_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.4-SNAPSHOT</version>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_18_R1</artifactId>

--- a/1_18_R2/pom.xml
+++ b/1_18_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.4-SNAPSHOT</version>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_18_R2</artifactId>

--- a/1_19_1_R1/pom.xml
+++ b/1_19_1_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.4-SNAPSHOT</version>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_1_R1</artifactId>

--- a/1_19_R1/pom.xml
+++ b/1_19_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.4-SNAPSHOT</version>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R1</artifactId>

--- a/1_19_R2/pom.xml
+++ b/1_19_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.4-SNAPSHOT</version>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R2</artifactId>

--- a/1_19_R3/pom.xml
+++ b/1_19_R3/pom.xml
@@ -3,10 +3,11 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.4-SNAPSHOT</version>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R3</artifactId>

--- a/1_7_R4/pom.xml
+++ b/1_7_R4/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.4-SNAPSHOT</version>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_7_R4</artifactId>

--- a/1_8_R1/pom.xml
+++ b/1_8_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.4-SNAPSHOT</version>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R1</artifactId>

--- a/1_8_R2/pom.xml
+++ b/1_8_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.4-SNAPSHOT</version>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R2</artifactId>

--- a/1_8_R3/pom.xml
+++ b/1_8_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.4-SNAPSHOT</version>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R3</artifactId>

--- a/1_9_R1/pom.xml
+++ b/1_9_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.4-SNAPSHOT</version>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_9_R1</artifactId>

--- a/1_9_R2/pom.xml
+++ b/1_9_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.4-SNAPSHOT</version>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_9_R2</artifactId>

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ AnvilGUI requires the usage of Maven or a Maven compatible build system.
 <dependency>
     <groupId>net.wesjd</groupId>
     <artifactId>anvilgui</artifactId>
-    <version>1.6.4-SNAPSHOT</version>
+    <version>1.6.5-SNAPSHOT</version>
 </dependency>
 
 <repository>

--- a/abstraction/pom.xml
+++ b/abstraction/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.4-SNAPSHOT</version>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-abstraction</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.4-SNAPSHOT</version>
+        <version>1.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui</artifactId>

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -90,8 +90,8 @@ public class AnvilGUI {
 
     /** An {@link Consumer} that is called when the anvil GUI is close */
     private final Consumer<StateSnapshot> closeListener;
-    /** A flag that decides the whether the async click handler can be run multiple times in parallel */
-    private final boolean parallelClickHandlerExecution;
+    /** A flag that decides whether the async click handler can be run concurrently */
+    private final boolean concurrentClickHandlerExecution;
     /** An {@link BiFunction} that is called when a slot is clicked */
     private final ClickHandler clickHandler;
 
@@ -124,7 +124,7 @@ public class AnvilGUI {
      * @param initialContents  The initial contents of the inventory
      * @param preventClose     Whether to prevent the inventory from closing
      * @param closeListener    A {@link Consumer} when the inventory closes
-     * @param parallelClickHandlerExecution Flag to allow parallel execution of the click handler
+     * @param concurrentClickHandlerExecution Flag to allow concurrent execution of the click handler
      * @param clickHandler     A {@link ClickHandler} that is called when the player clicks a slot
      */
     private AnvilGUI(
@@ -136,7 +136,7 @@ public class AnvilGUI {
             boolean preventClose,
             Set<Integer> interactableSlots,
             Consumer<StateSnapshot> closeListener,
-            boolean parallelClickHandlerExecution,
+            boolean concurrentClickHandlerExecution,
             ClickHandler clickHandler) {
         this.plugin = plugin;
         this.player = player;
@@ -146,7 +146,7 @@ public class AnvilGUI {
         this.preventClose = preventClose;
         this.interactableSlots = Collections.unmodifiableSet(interactableSlots);
         this.closeListener = closeListener;
-        this.parallelClickHandlerExecution = parallelClickHandlerExecution;
+        this.concurrentClickHandlerExecution = concurrentClickHandlerExecution;
         this.clickHandler = clickHandler;
     }
 
@@ -251,7 +251,7 @@ public class AnvilGUI {
             final int rawSlot = event.getRawSlot();
             if (rawSlot < 3 || event.getAction().equals(InventoryAction.MOVE_TO_OTHER_INVENTORY)) {
                 event.setCancelled(!interactableSlots.contains(rawSlot));
-                if (clickHandlerRunning && !parallelClickHandlerExecution) {
+                if (clickHandlerRunning && !concurrentClickHandlerExecution) {
                     // A click handler is running, don't launch another one
                     return;
                 }
@@ -321,8 +321,8 @@ public class AnvilGUI {
         private Executor mainThreadExecutor;
         /** An {@link Consumer} that is called when the anvil GUI is close */
         private Consumer<StateSnapshot> closeListener;
-        /** A flag that decides the whether the async click handler can be run multiple times in parallel */
-        private boolean parallelClickHandlerExecution = false;
+        /** A flag that decides whether the async click handler can be run concurrently */
+        private boolean concurrentClickHandlerExecution = false;
         /** An {@link Function} that is called when a slot in the inventory has been clicked */
         private ClickHandler clickHandler;
         /** A state that decides where the anvil GUI is able to be closed by the user */
@@ -398,7 +398,7 @@ public class AnvilGUI {
          * Do an action when a slot is clicked in the inventory
          * <p>
          * The ClickHandler is only called when the previous execution of the ClickHandler has finished.
-         * To alter this behaviour use {@link #allowParallelClickHandlerExecution()}
+         * To alter this behaviour use {@link #allowConcurrentClickHandlerExecution()}
          *
          * @param clickHandler A {@link ClickHandler} that is called when the user clicks a slot. The
          *                     {@link Integer} is the slot number corresponding to {@link Slot}, the
@@ -415,7 +415,7 @@ public class AnvilGUI {
         }
 
         /**
-         * By default, the {@link #onClickAsync(ClickHandler) async click handler} will not run in parallel
+         * By default, the {@link #onClickAsync(ClickHandler) async click handler} will not run concurrently
          * and instead wait for the previous {@link CompletableFuture} to finish before executing it again.
          * <p>
          * If this trait is desired, it can be enabled by calling this method but may lead to inconsistent
@@ -423,8 +423,8 @@ public class AnvilGUI {
          *
          * @return The {@link Builder} instance
          */
-        public Builder allowParallelClickHandlerExecution() {
-            this.parallelClickHandlerExecution = true;
+        public Builder allowConcurrentClickHandlerExecution() {
+            this.concurrentClickHandlerExecution = true;
             return this;
         }
 
@@ -556,7 +556,7 @@ public class AnvilGUI {
                     preventClose,
                     interactableSlots,
                     closeListener,
-                    parallelClickHandlerExecution,
+                    concurrentClickHandlerExecution,
                     clickHandler);
             anvilGUI.openInventory();
             return anvilGUI;

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -347,6 +347,7 @@ public class AnvilGUI {
          *
          * @param executor The executor to run tasks on
          * @return The {@link Builder} instance
+         * @throws IllegalArgumentException when the executor is null
          */
         public Builder mainThreadExecutor(Executor executor) {
             Validate.notNull(executor, "Executor cannot be null");

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -90,6 +90,8 @@ public class AnvilGUI {
 
     /** An {@link Consumer} that is called when the anvil GUI is close */
     private final Consumer<StateSnapshot> closeListener;
+    /** A flag that decides the whether the async click handler can be run multiple times in parallel */
+    private final boolean parallelClickHandlerExecution;
     /** An {@link BiFunction} that is called when a slot is clicked */
     private final ClickHandler clickHandler;
 
@@ -117,11 +119,13 @@ public class AnvilGUI {
      *
      * @param plugin           A {@link org.bukkit.plugin.java.JavaPlugin} instance
      * @param player           The {@link Player} to open the inventory for
+     * @param mainThreadExecutor An {@link Executor} that executes on the main server thread
      * @param inventoryTitle   What to have the text already set to
      * @param initialContents  The initial contents of the inventory
      * @param preventClose     Whether to prevent the inventory from closing
      * @param closeListener    A {@link Consumer} when the inventory closes
-     * @param clickHandler     A {@link BiFunction} that is called when the player clicks a slot
+     * @param parallelClickHandlerExecution Flag to allow parallel execution of the click handler
+     * @param clickHandler     A {@link ClickHandler} that is called when the player clicks a slot
      */
     private AnvilGUI(
             Plugin plugin,
@@ -132,6 +136,7 @@ public class AnvilGUI {
             boolean preventClose,
             Set<Integer> interactableSlots,
             Consumer<StateSnapshot> closeListener,
+            boolean parallelClickHandlerExecution,
             ClickHandler clickHandler) {
         this.plugin = plugin;
         this.player = player;
@@ -141,6 +146,7 @@ public class AnvilGUI {
         this.preventClose = preventClose;
         this.interactableSlots = Collections.unmodifiableSet(interactableSlots);
         this.closeListener = closeListener;
+        this.parallelClickHandlerExecution = parallelClickHandlerExecution;
         this.clickHandler = clickHandler;
     }
 
@@ -245,15 +251,13 @@ public class AnvilGUI {
             final int rawSlot = event.getRawSlot();
             if (rawSlot < 3 || event.getAction().equals(InventoryAction.MOVE_TO_OTHER_INVENTORY)) {
                 event.setCancelled(!interactableSlots.contains(rawSlot));
-                if (clickHandlerRunning) {
+                if (clickHandlerRunning && !parallelClickHandlerExecution) {
                     // A click handler is running, don't launch another one
                     return;
                 }
 
                 final CompletableFuture<List<ResponseAction>> actionsFuture =
                         clickHandler.apply(rawSlot, StateSnapshot.fromAnvilGUI(AnvilGUI.this));
-                // Set to running after calling the ClickHandler if the ClickHandler instantly throws an exception
-                clickHandlerRunning = true;
 
                 final Consumer<List<ResponseAction>> actionsConsumer = actions -> {
                     for (final ResponseAction action : actions) {
@@ -262,14 +266,11 @@ public class AnvilGUI {
                 };
 
                 if (actionsFuture.isDone()) {
-                    clickHandlerRunning = false;
                     // Fast-path without scheduling if clickHandler is performed in sync
-                    actionsFuture.thenAccept(actionsConsumer).exceptionally(exception -> {
-                        plugin.getLogger()
-                                .log(Level.SEVERE, "An exception occurred in the AnvilGUI clickHandler", exception);
-                        return null;
-                    });
+                    // Because the future is already completed, .join() will not block the server thread
+                    actionsFuture.thenAccept(actionsConsumer).join();
                 } else {
+                    clickHandlerRunning = true;
                     // If the plugin is disabled and the Executor throws an exception, the exception will be passed to
                     // the .handle method
                     actionsFuture
@@ -320,6 +321,8 @@ public class AnvilGUI {
         private Executor mainThreadExecutor;
         /** An {@link Consumer} that is called when the anvil GUI is close */
         private Consumer<StateSnapshot> closeListener;
+        /** A flag that decides the whether the async click handler can be run multiple times in parallel */
+        private boolean parallelClickHandlerExecution = false;
         /** An {@link Function} that is called when a slot in the inventory has been clicked */
         private ClickHandler clickHandler;
         /** A state that decides where the anvil GUI is able to be closed by the user */
@@ -394,6 +397,7 @@ public class AnvilGUI {
          * Do an action when a slot is clicked in the inventory
          * <p>
          * The ClickHandler is only called when the previous execution of the ClickHandler has finished.
+         * To alter this behaviour use {@link #allowParallelClickHandlerExecution()}
          *
          * @param clickHandler A {@link ClickHandler} that is called when the user clicks a slot. The
          *                     {@link Integer} is the slot number corresponding to {@link Slot}, the
@@ -406,6 +410,20 @@ public class AnvilGUI {
         public Builder onClickAsync(ClickHandler clickHandler) {
             Validate.notNull(clickHandler, "click function cannot be null");
             this.clickHandler = clickHandler;
+            return this;
+        }
+
+        /**
+         * By default, the {@link #onClickAsync(ClickHandler) async click handler} will not run in parallel
+         * and instead wait for the previous {@link CompletableFuture} to finish before executing it again.
+         * <p>
+         * If this trait is desired, it can be enabled by calling this method but may lead to inconsistent
+         * behaviour if not handled properly.
+         *
+         * @return The {@link Builder} instance
+         */
+        public Builder allowParallelClickHandlerExecution() {
+            this.parallelClickHandlerExecution = true;
             return this;
         }
 
@@ -537,6 +555,7 @@ public class AnvilGUI {
                     preventClose,
                     interactableSlots,
                     closeListener,
+                    parallelClickHandlerExecution,
                     clickHandler);
             anvilGUI.openInventory();
             return anvilGUI;

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -90,7 +90,7 @@ public class AnvilGUI {
     /** An {@link Consumer} that is called when the anvil GUI is close */
     private final Consumer<StateSnapshot> closeListener;
     /** An {@link BiFunction} that is called when a slot is clicked */
-    private final BiFunction<Integer, StateSnapshot, CompletableFuture<List<ResponseAction>>> clickHandler;
+    private final ClickHandler clickHandler;
 
     /**
      * The container id of the inventory, used for NMS methods
@@ -131,7 +131,7 @@ public class AnvilGUI {
             boolean preventClose,
             Set<Integer> interactableSlots,
             Consumer<StateSnapshot> closeListener,
-            BiFunction<Integer, StateSnapshot, CompletableFuture<List<ResponseAction>>> clickHandler) {
+            ClickHandler clickHandler) {
         this.plugin = plugin;
         this.player = player;
         this.mainThreadExecutor = mainThreadExecutor;
@@ -287,7 +287,7 @@ public class AnvilGUI {
         /** An {@link Consumer} that is called when the anvil GUI is close */
         private Consumer<StateSnapshot> closeListener;
         /** An {@link Function} that is called when a slot in the inventory has been clicked */
-        private BiFunction<Integer, StateSnapshot, CompletableFuture<List<ResponseAction>>> clickHandler;
+        private ClickHandler clickHandler;
         /** A state that decides where the anvil GUI is able to be closed by the user */
         private boolean preventClose = false;
         /** A set of integers containing the slot numbers that should be modifiable by the user. */
@@ -359,7 +359,7 @@ public class AnvilGUI {
         /**
          * Do an action when a slot is clicked in the inventory
          *
-         * @param clickHandler An {@link BiFunction} that is called when the user clicks a slot. The
+         * @param clickHandler A {@link ClickHandler} that is called when the user clicks a slot. The
          *                     {@link Integer} is the slot number corresponding to {@link Slot}, the
          *                     {@link StateSnapshot} contains information about the current state of the anvil,
          *                     and the response is a {@link CompletableFuture} that will eventually return a
@@ -367,8 +367,7 @@ public class AnvilGUI {
          * @return The {@link Builder} instance
          * @throws IllegalArgumentException when the function supplied is null
          */
-        public Builder onClickAsync(
-                BiFunction<Integer, StateSnapshot, CompletableFuture<List<ResponseAction>>> clickHandler) {
+        public Builder onClickAsync(ClickHandler clickHandler) {
             Validate.notNull(clickHandler, "click function cannot be null");
             this.clickHandler = clickHandler;
             return this;
@@ -377,7 +376,7 @@ public class AnvilGUI {
         /**
          * Do an action when a slot is clicked in the inventory
          *
-         * @param clickHandler An {@link BiFunction} that is called when the user clicks a slot. The
+         * @param clickHandler A {@link BiFunction} that is called when the user clicks a slot. The
          *                     {@link Integer} is the slot number corresponding to {@link Slot}, the
          *                     {@link StateSnapshot} contains information about the current state of the anvil,
          *                     and the response is a list of {@link ResponseAction} to execute in the order
@@ -508,8 +507,19 @@ public class AnvilGUI {
         }
     }
 
+    /**
+     * A handler that is called when the user clicks a slot. The
+     * {@link Integer} is the slot number corresponding to {@link Slot}, the
+     * {@link StateSnapshot} contains information about the current state of the anvil,
+     * and the response is a {@link CompletableFuture} that will eventually return a
+     * list of {@link ResponseAction} to execute in the order that they are supplied.
+     */
+    @FunctionalInterface
+    public interface ClickHandler extends BiFunction<Integer, StateSnapshot, CompletableFuture<List<ResponseAction>>> {}
+
     /** An action to run in response to a player clicking the output slot in the GUI. This interface is public
      * and permits you, the developer, to add additional response features easily to your custom AnvilGUIs. */
+    @FunctionalInterface
     public interface ResponseAction extends BiConsumer<AnvilGUI, Player> {
 
         /**

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.wesjd</groupId>
     <artifactId>anvilgui-parent</artifactId>
-    <version>1.6.4-SNAPSHOT</version>
+    <version>1.6.5-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
Added `onClickAsync` function that allows to compute the resulting ResponseActions asynchronously.

My current use case would be that I have to check that the player input is valid by interacting with a database, which is less ideal to do on the main server thread.

To make sure that the result is always executed on the main server thread I had to use an `Executor` anyway, so I made that customizable via the Builder, which would enable this library to also work on [Folia](https://papermc.io/software/folia) by allowing plugin developers to provide a Folia aware executor.