### PR TITLE
Updated VersionMatcher to not use deprecated Class.newInstance()

### DIFF
--- a/api/src/main/java/net/wesjd/anvilgui/version/VersionMatcher.java
+++ b/api/src/main/java/net/wesjd/anvilgui/version/VersionMatcher.java
@@ -26,13 +26,14 @@ public class VersionMatcher {
                 .substring(1);
         try {
             return (VersionWrapper) Class.forName(getClass().getPackage().getName() + ".Wrapper" + serverVersion)
+                    .getDeclaredConstructor()
                     .newInstance();
-        } catch (IllegalAccessException | InstantiationException exception) {
-            throw new IllegalStateException(
-                    "Failed to instantiate version wrapper for version " + serverVersion, exception);
         } catch (ClassNotFoundException exception) {
             throw new IllegalStateException(
                     "AnvilGUI does not support server version \"" + serverVersion + "\"", exception);
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException(
+                    "Failed to instantiate version wrapper for version " + serverVersion, exception);
         }
     }
 }


### PR DESCRIPTION
Class.newInstance() has been deprecated since Java 9.
Rearranged the thrown exceptions because additional exceptions are now thrown.