### PR TITLE
Raw chat components for inventory titles

### DIFF
--- a/1_10_R1/pom.xml
+++ b/1_10_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_10_R1</artifactId>

--- a/1_10_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_10_R1.java
+++ b/1_10_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_10_R1.java
@@ -38,7 +38,8 @@ public class Wrapper1_10_R1 implements VersionWrapper {
     public void sendPacketOpenWindow(Player player, int containerId, Object guiTitle) {
         toNMS(player)
                 .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", (IChatBaseComponent) guiTitle));
+                .sendPacket(new PacketPlayOutOpenWindow(
+                        containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
     }
 
     /**
@@ -99,12 +100,12 @@ public class Wrapper1_10_R1 implements VersionWrapper {
 
     @Override
     public Object literalChatComponent(String content) {
-        return new ChatComponentText(content);
+        return null;
     }
 
     @Override
     public Object jsonChatComponent(String json) {
-        return IChatBaseComponent.ChatSerializer.a(json);
+        return null;
     }
 
     /**

--- a/1_10_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_10_R1.java
+++ b/1_10_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_10_R1.java
@@ -35,11 +35,10 @@ public class Wrapper1_10_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
+    public void sendPacketOpenWindow(Player player, int containerId, Object guiTitle) {
         toNMS(player)
                 .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(
-                        containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
+                .sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", (IChatBaseComponent) guiTitle));
     }
 
     /**
@@ -94,8 +93,18 @@ public class Wrapper1_10_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player, String guiTitle) {
+    public Object newContainerAnvil(Player player, Object guiTitle) {
         return new Wrapper1_10_R1.AnvilContainer(toNMS(player));
+    }
+
+    @Override
+    public Object literalChatComponent(String content) {
+        return new ChatComponentText(content);
+    }
+
+    @Override
+    public Object jsonChatComponent(String json) {
+        return IChatBaseComponent.ChatSerializer.a(json);
     }
 
     /**

--- a/1_11_R1/pom.xml
+++ b/1_11_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_11_R1</artifactId>

--- a/1_11_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_11_R1.java
+++ b/1_11_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_11_R1.java
@@ -35,11 +35,10 @@ public class Wrapper1_11_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
+    public void sendPacketOpenWindow(Player player, int containerId, Object guiTitle) {
         toNMS(player)
                 .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(
-                        containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
+                .sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", (IChatBaseComponent) guiTitle));
     }
 
     /**
@@ -94,8 +93,18 @@ public class Wrapper1_11_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player, String guiTitle) {
+    public Object newContainerAnvil(Player player, Object guiTitle) {
         return new Wrapper1_11_R1.AnvilContainer(toNMS(player));
+    }
+
+    @Override
+    public Object literalChatComponent(String content) {
+        return new ChatComponentText(content);
+    }
+
+    @Override
+    public Object jsonChatComponent(String json) {
+        return IChatBaseComponent.ChatSerializer.a(json);
     }
 
     /**

--- a/1_11_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_11_R1.java
+++ b/1_11_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_11_R1.java
@@ -38,7 +38,8 @@ public class Wrapper1_11_R1 implements VersionWrapper {
     public void sendPacketOpenWindow(Player player, int containerId, Object guiTitle) {
         toNMS(player)
                 .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", (IChatBaseComponent) guiTitle));
+                .sendPacket(new PacketPlayOutOpenWindow(
+                        containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
     }
 
     /**
@@ -99,12 +100,12 @@ public class Wrapper1_11_R1 implements VersionWrapper {
 
     @Override
     public Object literalChatComponent(String content) {
-        return new ChatComponentText(content);
+        return null;
     }
 
     @Override
     public Object jsonChatComponent(String json) {
-        return IChatBaseComponent.ChatSerializer.a(json);
+        return null;
     }
 
     /**

--- a/1_12_R1/pom.xml
+++ b/1_12_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_12_R1</artifactId>

--- a/1_12_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_12_R1.java
+++ b/1_12_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_12_R1.java
@@ -38,7 +38,8 @@ public class Wrapper1_12_R1 implements VersionWrapper {
     public void sendPacketOpenWindow(Player player, int containerId, Object guiTitle) {
         toNMS(player)
                 .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", (IChatBaseComponent) guiTitle));
+                .sendPacket(new PacketPlayOutOpenWindow(
+                        containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
     }
 
     /**
@@ -99,12 +100,12 @@ public class Wrapper1_12_R1 implements VersionWrapper {
 
     @Override
     public Object literalChatComponent(String content) {
-        return new ChatComponentText(content);
+        return null;
     }
 
     @Override
     public Object jsonChatComponent(String json) {
-        return IChatBaseComponent.ChatSerializer.a(json);
+        return null;
     }
 
     /**

--- a/1_12_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_12_R1.java
+++ b/1_12_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_12_R1.java
@@ -35,11 +35,10 @@ public class Wrapper1_12_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
+    public void sendPacketOpenWindow(Player player, int containerId, Object guiTitle) {
         toNMS(player)
                 .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(
-                        containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
+                .sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", (IChatBaseComponent) guiTitle));
     }
 
     /**
@@ -94,8 +93,18 @@ public class Wrapper1_12_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player, String guiTitle) {
+    public Object newContainerAnvil(Player player, Object guiTitle) {
         return new Wrapper1_12_R1.AnvilContainer(toNMS(player));
+    }
+
+    @Override
+    public Object literalChatComponent(String content) {
+        return new ChatComponentText(content);
+    }
+
+    @Override
+    public Object jsonChatComponent(String json) {
+        return IChatBaseComponent.ChatSerializer.a(json);
     }
 
     /**

--- a/1_13_R1/pom.xml
+++ b/1_13_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_13_R1</artifactId>

--- a/1_13_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R1.java
+++ b/1_13_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R1.java
@@ -38,7 +38,8 @@ public class Wrapper1_13_R1 implements VersionWrapper {
     public void sendPacketOpenWindow(Player player, int containerId, Object guiTitle) {
         toNMS(player)
                 .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", (IChatBaseComponent) guiTitle));
+                .sendPacket(new PacketPlayOutOpenWindow(
+                        containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
     }
 
     /**
@@ -99,12 +100,12 @@ public class Wrapper1_13_R1 implements VersionWrapper {
 
     @Override
     public Object literalChatComponent(String content) {
-        return new ChatComponentText(content);
+        return null;
     }
 
     @Override
     public Object jsonChatComponent(String json) {
-        return IChatBaseComponent.ChatSerializer.a(json);
+        return null;
     }
 
     /**

--- a/1_13_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R1.java
+++ b/1_13_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R1.java
@@ -35,11 +35,10 @@ public class Wrapper1_13_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
+    public void sendPacketOpenWindow(Player player, int containerId, Object guiTitle) {
         toNMS(player)
                 .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(
-                        containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
+                .sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", (IChatBaseComponent) guiTitle));
     }
 
     /**
@@ -94,8 +93,18 @@ public class Wrapper1_13_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player, String guiTitle) {
+    public Object newContainerAnvil(Player player, Object guiTitle) {
         return new Wrapper1_13_R1.AnvilContainer(toNMS(player));
+    }
+
+    @Override
+    public Object literalChatComponent(String content) {
+        return new ChatComponentText(content);
+    }
+
+    @Override
+    public Object jsonChatComponent(String json) {
+        return IChatBaseComponent.ChatSerializer.a(json);
     }
 
     /**

--- a/1_13_R2/pom.xml
+++ b/1_13_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_13_R2</artifactId>

--- a/1_13_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R2.java
+++ b/1_13_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R2.java
@@ -35,11 +35,10 @@ public class Wrapper1_13_R2 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
+    public void sendPacketOpenWindow(Player player, int containerId, Object guiTitle) {
         toNMS(player)
                 .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(
-                        containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
+                .sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", (IChatBaseComponent) guiTitle));
     }
 
     /**
@@ -94,8 +93,18 @@ public class Wrapper1_13_R2 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player, String guiTitle) {
+    public Object newContainerAnvil(Player player, Object guiTitle) {
         return new Wrapper1_13_R2.AnvilContainer(toNMS(player));
+    }
+
+    @Override
+    public Object literalChatComponent(String content) {
+        return new ChatComponentText(content);
+    }
+
+    @Override
+    public Object jsonChatComponent(String json) {
+        return IChatBaseComponent.ChatSerializer.a(json);
     }
 
     /**

--- a/1_13_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R2.java
+++ b/1_13_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R2.java
@@ -38,7 +38,8 @@ public class Wrapper1_13_R2 implements VersionWrapper {
     public void sendPacketOpenWindow(Player player, int containerId, Object guiTitle) {
         toNMS(player)
                 .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", (IChatBaseComponent) guiTitle));
+                .sendPacket(new PacketPlayOutOpenWindow(
+                        containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
     }
 
     /**
@@ -99,12 +100,12 @@ public class Wrapper1_13_R2 implements VersionWrapper {
 
     @Override
     public Object literalChatComponent(String content) {
-        return new ChatComponentText(content);
+        return null;
     }
 
     @Override
     public Object jsonChatComponent(String json) {
-        return IChatBaseComponent.ChatSerializer.a(json);
+        return null;
     }
 
     /**

--- a/1_14_4_R1/pom.xml
+++ b/1_14_4_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_14_4_R1</artifactId>

--- a/1_14_4_R1/src/main/java/net/wesjd/anvilgui/version/special/AnvilContainer1_14_4_R1.java
+++ b/1_14_4_R1/src/main/java/net/wesjd/anvilgui/version/special/AnvilContainer1_14_4_R1.java
@@ -8,13 +8,13 @@ import org.bukkit.entity.Player;
 
 public class AnvilContainer1_14_4_R1 extends ContainerAnvil {
 
-    public AnvilContainer1_14_4_R1(Player player, int containerId, String guiTitle) {
+    public AnvilContainer1_14_4_R1(Player player, int containerId, IChatBaseComponent guiTitle) {
         super(
                 containerId,
                 ((CraftPlayer) player).getHandle().inventory,
                 ContainerAccess.at(((CraftWorld) player.getWorld()).getHandle(), new BlockPosition(0, 0, 0)));
         this.checkReachable = false;
-        setTitle(new ChatMessage(guiTitle));
+        setTitle(guiTitle);
     }
 
     @Override

--- a/1_14_R1/pom.xml
+++ b/1_14_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_14_R1</artifactId>

--- a/1_14_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_14_R1.java
+++ b/1_14_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_14_R1.java
@@ -42,10 +42,10 @@ public class Wrapper1_14_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
+    public void sendPacketOpenWindow(Player player, int containerId, Object guiTitle) {
         toNMS(player)
                 .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(containerId, Containers.ANVIL, new ChatMessage(guiTitle)));
+                .sendPacket(new PacketPlayOutOpenWindow(containerId, Containers.ANVIL, (IChatBaseComponent) guiTitle));
     }
 
     /**
@@ -100,12 +100,22 @@ public class Wrapper1_14_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player, String guiTitle) {
+    public Object newContainerAnvil(Player player, Object guiTitle) {
         if (IS_ONE_FOURTEEN) {
-            return new AnvilContainer1_14_4_R1(player, getRealNextContainerId(player), guiTitle);
+            return new AnvilContainer1_14_4_R1(player, getRealNextContainerId(player), (IChatBaseComponent) guiTitle);
         } else {
-            return new Wrapper1_14_R1.AnvilContainer(player, guiTitle);
+            return new Wrapper1_14_R1.AnvilContainer(player, (IChatBaseComponent) guiTitle);
         }
+    }
+
+    @Override
+    public Object literalChatComponent(String content) {
+        return new ChatComponentText(content);
+    }
+
+    @Override
+    public Object jsonChatComponent(String json) {
+        return IChatBaseComponent.ChatSerializer.a(json);
     }
 
     /**
@@ -123,13 +133,13 @@ public class Wrapper1_14_R1 implements VersionWrapper {
      */
     private class AnvilContainer extends ContainerAnvil {
 
-        public AnvilContainer(Player player, String guiTitle) {
+        public AnvilContainer(Player player, IChatBaseComponent guiTitle) {
             super(
                     getRealNextContainerId(player),
                     ((CraftPlayer) player).getHandle().inventory,
                     ContainerAccess.at(((CraftWorld) player.getWorld()).getHandle(), new BlockPosition(0, 0, 0)));
             this.checkReachable = false;
-            setTitle(new ChatMessage(guiTitle));
+            setTitle(guiTitle);
         }
 
         @Override

--- a/1_15_R1/pom.xml
+++ b/1_15_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_15_R1</artifactId>

--- a/1_15_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_15_R1.java
+++ b/1_15_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_15_R1.java
@@ -33,10 +33,10 @@ public class Wrapper1_15_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
+    public void sendPacketOpenWindow(Player player, int containerId, Object guiTitle) {
         toNMS(player)
                 .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(containerId, Containers.ANVIL, new ChatMessage(guiTitle)));
+                .sendPacket(new PacketPlayOutOpenWindow(containerId, Containers.ANVIL, (IChatBaseComponent) guiTitle));
     }
 
     /**
@@ -91,8 +91,18 @@ public class Wrapper1_15_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player, String guiTitle) {
-        return new AnvilContainer(player, guiTitle);
+    public Object newContainerAnvil(Player player, Object guiTitle) {
+        return new AnvilContainer(player, (IChatBaseComponent) guiTitle);
+    }
+
+    @Override
+    public Object literalChatComponent(String content) {
+        return new ChatComponentText(content);
+    }
+
+    @Override
+    public Object jsonChatComponent(String json) {
+        return IChatBaseComponent.ChatSerializer.a(json);
     }
 
     /**
@@ -110,13 +120,13 @@ public class Wrapper1_15_R1 implements VersionWrapper {
      */
     private class AnvilContainer extends ContainerAnvil {
 
-        public AnvilContainer(Player player, String guiTitle) {
+        public AnvilContainer(Player player, IChatBaseComponent guiTitle) {
             super(
                     getRealNextContainerId(player),
                     ((CraftPlayer) player).getHandle().inventory,
                     ContainerAccess.at(((CraftWorld) player.getWorld()).getHandle(), new BlockPosition(0, 0, 0)));
             this.checkReachable = false;
-            setTitle(new ChatMessage(guiTitle));
+            setTitle(guiTitle);
         }
 
         @Override

--- a/1_16_R1/pom.xml
+++ b/1_16_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R1</artifactId>

--- a/1_16_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R1.java
+++ b/1_16_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R1.java
@@ -33,10 +33,10 @@ public class Wrapper1_16_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
+    public void sendPacketOpenWindow(Player player, int containerId, Object guiTitle) {
         toNMS(player)
                 .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(containerId, Containers.ANVIL, new ChatMessage(guiTitle)));
+                .sendPacket(new PacketPlayOutOpenWindow(containerId, Containers.ANVIL, (IChatBaseComponent) guiTitle));
     }
 
     /**
@@ -91,8 +91,18 @@ public class Wrapper1_16_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player, String guiTitle) {
-        return new AnvilContainer(player, guiTitle);
+    public Object newContainerAnvil(Player player, Object guiTitle) {
+        return new AnvilContainer(player, (IChatBaseComponent) guiTitle);
+    }
+
+    @Override
+    public Object literalChatComponent(String content) {
+        return new ChatComponentText(content);
+    }
+
+    @Override
+    public Object jsonChatComponent(String json) {
+        return IChatBaseComponent.ChatSerializer.a(json);
     }
 
     /**
@@ -110,13 +120,13 @@ public class Wrapper1_16_R1 implements VersionWrapper {
      */
     private class AnvilContainer extends ContainerAnvil {
 
-        public AnvilContainer(Player player, String guiTitle) {
+        public AnvilContainer(Player player, IChatBaseComponent guiTitle) {
             super(
                     getRealNextContainerId(player),
                     ((CraftPlayer) player).getHandle().inventory,
                     ContainerAccess.at(((CraftWorld) player.getWorld()).getHandle(), new BlockPosition(0, 0, 0)));
             this.checkReachable = false;
-            setTitle(new ChatMessage(guiTitle));
+            setTitle(guiTitle);
         }
 
         @Override

--- a/1_16_R2/pom.xml
+++ b/1_16_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R2</artifactId>

--- a/1_16_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R2.java
+++ b/1_16_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R2.java
@@ -33,10 +33,10 @@ public class Wrapper1_16_R2 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
+    public void sendPacketOpenWindow(Player player, int containerId, Object guiTitle) {
         toNMS(player)
                 .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(containerId, Containers.ANVIL, new ChatMessage(guiTitle)));
+                .sendPacket(new PacketPlayOutOpenWindow(containerId, Containers.ANVIL, (IChatBaseComponent) guiTitle));
     }
 
     /**
@@ -91,8 +91,18 @@ public class Wrapper1_16_R2 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player, String guiTitle) {
-        return new AnvilContainer(player, guiTitle);
+    public Object newContainerAnvil(Player player, Object guiTitle) {
+        return new AnvilContainer(player, (IChatBaseComponent) guiTitle);
+    }
+
+    @Override
+    public Object literalChatComponent(String content) {
+        return new ChatComponentText(content);
+    }
+
+    @Override
+    public Object jsonChatComponent(String json) {
+        return IChatBaseComponent.ChatSerializer.a(json);
     }
 
     /**
@@ -110,13 +120,13 @@ public class Wrapper1_16_R2 implements VersionWrapper {
      */
     private class AnvilContainer extends ContainerAnvil {
 
-        public AnvilContainer(Player player, String guiTitle) {
+        public AnvilContainer(Player player, IChatBaseComponent guiTitle) {
             super(
                     getRealNextContainerId(player),
                     ((CraftPlayer) player).getHandle().inventory,
                     ContainerAccess.at(((CraftWorld) player.getWorld()).getHandle(), new BlockPosition(0, 0, 0)));
             this.checkReachable = false;
-            setTitle(new ChatMessage(guiTitle));
+            setTitle(guiTitle);
         }
 
         @Override

--- a/1_16_R3/pom.xml
+++ b/1_16_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R3</artifactId>

--- a/1_16_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R3.java
+++ b/1_16_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R3.java
@@ -33,10 +33,10 @@ public class Wrapper1_16_R3 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
+    public void sendPacketOpenWindow(Player player, int containerId, Object guiTitle) {
         toNMS(player)
                 .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(containerId, Containers.ANVIL, new ChatMessage(guiTitle)));
+                .sendPacket(new PacketPlayOutOpenWindow(containerId, Containers.ANVIL, (IChatBaseComponent) guiTitle));
     }
 
     /**
@@ -91,8 +91,18 @@ public class Wrapper1_16_R3 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player, String guiTitle) {
-        return new AnvilContainer(player, guiTitle);
+    public Object newContainerAnvil(Player player, Object guiTitle) {
+        return new AnvilContainer(player, (IChatBaseComponent) guiTitle);
+    }
+
+    @Override
+    public Object literalChatComponent(String content) {
+        return new ChatComponentText(content);
+    }
+
+    @Override
+    public Object jsonChatComponent(String json) {
+        return IChatBaseComponent.ChatSerializer.a(json);
     }
 
     /**
@@ -110,13 +120,13 @@ public class Wrapper1_16_R3 implements VersionWrapper {
      */
     private class AnvilContainer extends ContainerAnvil {
 
-        public AnvilContainer(Player player, String guiTitle) {
+        public AnvilContainer(Player player, IChatBaseComponent guiTitle) {
             super(
                     getRealNextContainerId(player),
                     ((CraftPlayer) player).getHandle().inventory,
                     ContainerAccess.at(((CraftWorld) player.getWorld()).getHandle(), new BlockPosition(0, 0, 0)));
             this.checkReachable = false;
-            setTitle(new ChatMessage(guiTitle));
+            setTitle(guiTitle);
         }
 
         @Override

--- a/1_17_1_R1/pom.xml
+++ b/1_17_1_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_17_1_R1</artifactId>

--- a/1_17_1_R1/src/main/java/net/wesjd/anvilgui/version/special/AnvilContainer1_17_1_R1.java
+++ b/1_17_1_R1/src/main/java/net/wesjd/anvilgui/version/special/AnvilContainer1_17_1_R1.java
@@ -2,7 +2,7 @@ package net.wesjd.anvilgui.version.special;
 
 
 import net.minecraft.core.BlockPosition;
-import net.minecraft.network.chat.ChatMessage;
+import net.minecraft.network.chat.IChatBaseComponent;
 import net.minecraft.world.IInventory;
 import net.minecraft.world.entity.player.EntityHuman;
 import net.minecraft.world.inventory.ContainerAccess;
@@ -12,13 +12,13 @@ import org.bukkit.craftbukkit.v1_17_R1.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
 public class AnvilContainer1_17_1_R1 extends ContainerAnvil {
-    public AnvilContainer1_17_1_R1(Player player, int containerId, String guiTitle) {
+    public AnvilContainer1_17_1_R1(Player player, int containerId, IChatBaseComponent guiTitle) {
         super(
                 containerId,
                 ((CraftPlayer) player).getHandle().getInventory(),
                 ContainerAccess.at(((CraftWorld) player.getWorld()).getHandle(), new BlockPosition(0, 0, 0)));
         this.checkReachable = false;
-        setTitle(new ChatMessage(guiTitle));
+        setTitle(guiTitle);
     }
 
     @Override

--- a/1_17_R1/pom.xml
+++ b/1_17_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_17_R1</artifactId>

--- a/1_17_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_17_R1.java
+++ b/1_17_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_17_R1.java
@@ -3,7 +3,7 @@ package net.wesjd.anvilgui.version;
 
 import net.minecraft.core.BlockPosition;
 import net.minecraft.network.chat.ChatComponentText;
-import net.minecraft.network.chat.ChatMessage;
+import net.minecraft.network.chat.IChatBaseComponent;
 import net.minecraft.network.protocol.game.PacketPlayOutCloseWindow;
 import net.minecraft.network.protocol.game.PacketPlayOutOpenWindow;
 import net.minecraft.server.level.EntityPlayer;
@@ -52,10 +52,9 @@ public class Wrapper1_17_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
-        toNMS(player)
-                .b
-                .sendPacket(new PacketPlayOutOpenWindow(containerId, Containers.h, new ChatComponentText(guiTitle)));
+    public void sendPacketOpenWindow(Player player, int containerId, Object guiTitle) {
+        toNMS(player).b.sendPacket(new PacketPlayOutOpenWindow(containerId, Containers.h, (IChatBaseComponent)
+                guiTitle));
     }
 
     /**
@@ -110,11 +109,21 @@ public class Wrapper1_17_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player, String guiTitle) {
+    public Object newContainerAnvil(Player player, Object guiTitle) {
         if (IS_ONE_SEVENTEEN_ONE) {
-            return new AnvilContainer1_17_1_R1(player, getRealNextContainerId(player), guiTitle);
+            return new AnvilContainer1_17_1_R1(player, getRealNextContainerId(player), (IChatBaseComponent) guiTitle);
         }
-        return new AnvilContainer(player, guiTitle);
+        return new AnvilContainer(player, (IChatBaseComponent) guiTitle);
+    }
+
+    @Override
+    public Object literalChatComponent(String content) {
+        return new ChatComponentText(content);
+    }
+
+    @Override
+    public Object jsonChatComponent(String json) {
+        return IChatBaseComponent.ChatSerializer.a(json);
     }
 
     /**
@@ -131,13 +140,13 @@ public class Wrapper1_17_R1 implements VersionWrapper {
      * Modifications to ContainerAnvil that makes it so you don't have to have xp to use this anvil
      */
     private class AnvilContainer extends ContainerAnvil {
-        public AnvilContainer(Player player, String guiTitle) {
+        public AnvilContainer(Player player, IChatBaseComponent guiTitle) {
             super(
                     Wrapper1_17_R1.this.getRealNextContainerId(player),
                     ((CraftPlayer) player).getHandle().getInventory(),
                     ContainerAccess.at(((CraftWorld) player.getWorld()).getHandle(), new BlockPosition(0, 0, 0)));
             this.checkReachable = false;
-            setTitle(new ChatMessage(guiTitle));
+            setTitle(guiTitle);
         }
 
         @Override

--- a/1_18_R1/pom.xml
+++ b/1_18_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_18_R1</artifactId>

--- a/1_18_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_18_R1.java
+++ b/1_18_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_18_R1.java
@@ -3,7 +3,7 @@ package net.wesjd.anvilgui.version;
 
 import net.minecraft.core.BlockPosition;
 import net.minecraft.network.chat.ChatComponentText;
-import net.minecraft.network.chat.ChatMessage;
+import net.minecraft.network.chat.IChatBaseComponent;
 import net.minecraft.network.protocol.game.PacketPlayOutCloseWindow;
 import net.minecraft.network.protocol.game.PacketPlayOutOpenWindow;
 import net.minecraft.server.level.EntityPlayer;
@@ -45,10 +45,8 @@ public final class Wrapper1_18_R1 implements VersionWrapper {
     }
 
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId, String inventoryTitle) {
-        toNMS(player)
-                .b
-                .a(new PacketPlayOutOpenWindow(containerId, Containers.h, new ChatComponentText(inventoryTitle)));
+    public void sendPacketOpenWindow(Player player, int containerId, Object inventoryTitle) {
+        toNMS(player).b.a(new PacketPlayOutOpenWindow(containerId, Containers.h, (IChatBaseComponent) inventoryTitle));
     }
 
     @Override
@@ -80,18 +78,28 @@ public final class Wrapper1_18_R1 implements VersionWrapper {
     }
 
     @Override
-    public Object newContainerAnvil(Player player, String title) {
-        return new AnvilContainer(player, getRealNextContainerId(player), title);
+    public Object newContainerAnvil(Player player, Object title) {
+        return new AnvilContainer(player, getRealNextContainerId(player), (IChatBaseComponent) title);
+    }
+
+    @Override
+    public Object literalChatComponent(String content) {
+        return new ChatComponentText(content);
+    }
+
+    @Override
+    public Object jsonChatComponent(String json) {
+        return IChatBaseComponent.ChatSerializer.a(json);
     }
 
     private static class AnvilContainer extends ContainerAnvil {
-        public AnvilContainer(Player player, int containerId, String guiTitle) {
+        public AnvilContainer(Player player, int containerId, IChatBaseComponent guiTitle) {
             super(
                     containerId,
                     ((CraftPlayer) player).getHandle().fq(),
                     ContainerAccess.a(((CraftWorld) player.getWorld()).getHandle(), new BlockPosition(0, 0, 0)));
             this.checkReachable = false;
-            setTitle(new ChatMessage(guiTitle));
+            setTitle(guiTitle);
         }
 
         @Override

--- a/1_18_R2/pom.xml
+++ b/1_18_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_18_R2</artifactId>

--- a/1_18_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_18_R2.java
+++ b/1_18_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_18_R2.java
@@ -3,7 +3,7 @@ package net.wesjd.anvilgui.version;
 
 import net.minecraft.core.BlockPosition;
 import net.minecraft.network.chat.ChatComponentText;
-import net.minecraft.network.chat.ChatMessage;
+import net.minecraft.network.chat.IChatBaseComponent;
 import net.minecraft.network.protocol.game.PacketPlayOutCloseWindow;
 import net.minecraft.network.protocol.game.PacketPlayOutOpenWindow;
 import net.minecraft.server.level.EntityPlayer;
@@ -45,10 +45,8 @@ public final class Wrapper1_18_R2 implements VersionWrapper {
     }
 
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId, String inventoryTitle) {
-        toNMS(player)
-                .b
-                .a(new PacketPlayOutOpenWindow(containerId, Containers.h, new ChatComponentText(inventoryTitle)));
+    public void sendPacketOpenWindow(Player player, int containerId, Object inventoryTitle) {
+        toNMS(player).b.a(new PacketPlayOutOpenWindow(containerId, Containers.h, (IChatBaseComponent) inventoryTitle));
     }
 
     @Override
@@ -80,18 +78,28 @@ public final class Wrapper1_18_R2 implements VersionWrapper {
     }
 
     @Override
-    public Object newContainerAnvil(Player player, String title) {
-        return new AnvilContainer(player, getRealNextContainerId(player), title);
+    public Object newContainerAnvil(Player player, Object title) {
+        return new AnvilContainer(player, getRealNextContainerId(player), (IChatBaseComponent) title);
+    }
+
+    @Override
+    public Object literalChatComponent(String content) {
+        return new ChatComponentText(content);
+    }
+
+    @Override
+    public Object jsonChatComponent(String json) {
+        return IChatBaseComponent.ChatSerializer.a(json);
     }
 
     private static class AnvilContainer extends ContainerAnvil {
-        public AnvilContainer(Player player, int containerId, String guiTitle) {
+        public AnvilContainer(Player player, int containerId, IChatBaseComponent guiTitle) {
             super(
                     containerId,
                     ((CraftPlayer) player).getHandle().fr(),
                     ContainerAccess.a(((CraftWorld) player.getWorld()).getHandle(), new BlockPosition(0, 0, 0)));
             this.checkReachable = false;
-            setTitle(new ChatMessage(guiTitle));
+            setTitle(guiTitle);
         }
 
         @Override

--- a/1_19_1_R1/pom.xml
+++ b/1_19_1_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_1_R1</artifactId>

--- a/1_19_1_R1/src/main/java/net/wesjd/anvilgui/version/special/AnvilContainer1_19_1_R1.java
+++ b/1_19_1_R1/src/main/java/net/wesjd/anvilgui/version/special/AnvilContainer1_19_1_R1.java
@@ -12,13 +12,13 @@ import org.bukkit.craftbukkit.v1_19_R1.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
 public class AnvilContainer1_19_1_R1 extends ContainerAnvil {
-    public AnvilContainer1_19_1_R1(Player player, int containerId, String guiTitle) {
+    public AnvilContainer1_19_1_R1(Player player, int containerId, IChatBaseComponent guiTitle) {
         super(
                 containerId,
                 ((CraftPlayer) player).getHandle().fA(),
                 ContainerAccess.a(((CraftWorld) player.getWorld()).getHandle(), new BlockPosition(0, 0, 0)));
         this.checkReachable = false;
-        setTitle(IChatBaseComponent.a(guiTitle));
+        setTitle(guiTitle);
     }
 
     @Override

--- a/1_19_R1/pom.xml
+++ b/1_19_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R1</artifactId>

--- a/1_19_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_19_R1.java
+++ b/1_19_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_19_R1.java
@@ -52,8 +52,8 @@ public final class Wrapper1_19_R1 implements VersionWrapper {
     }
 
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId, String inventoryTitle) {
-        toNMS(player).b.a(new PacketPlayOutOpenWindow(containerId, Containers.h, IChatBaseComponent.a(inventoryTitle)));
+    public void sendPacketOpenWindow(Player player, int containerId, Object inventoryTitle) {
+        toNMS(player).b.a(new PacketPlayOutOpenWindow(containerId, Containers.h, (IChatBaseComponent) inventoryTitle));
     }
 
     @Override
@@ -85,21 +85,31 @@ public final class Wrapper1_19_R1 implements VersionWrapper {
     }
 
     @Override
-    public Object newContainerAnvil(Player player, String title) {
+    public Object newContainerAnvil(Player player, Object title) {
         if (IS_ONE_NINETEEN_ONE) {
-            return new AnvilContainer1_19_1_R1(player, getRealNextContainerId(player), title);
+            return new AnvilContainer1_19_1_R1(player, getRealNextContainerId(player), (IChatBaseComponent) title);
         }
-        return new AnvilContainer(player, getRealNextContainerId(player), title);
+        return new AnvilContainer(player, getRealNextContainerId(player), (IChatBaseComponent) title);
+    }
+
+    @Override
+    public Object literalChatComponent(String content) {
+        return IChatBaseComponent.b(content);
+    }
+
+    @Override
+    public Object jsonChatComponent(String json) {
+        return IChatBaseComponent.ChatSerializer.a(json);
     }
 
     private static class AnvilContainer extends ContainerAnvil {
-        public AnvilContainer(Player player, int containerId, String guiTitle) {
+        public AnvilContainer(Player player, int containerId, IChatBaseComponent guiTitle) {
             super(
                     containerId,
                     ((CraftPlayer) player).getHandle().fB(),
                     ContainerAccess.a(((CraftWorld) player.getWorld()).getHandle(), new BlockPosition(0, 0, 0)));
             this.checkReachable = false;
-            setTitle(IChatBaseComponent.a(guiTitle));
+            setTitle(guiTitle);
         }
 
         @Override

--- a/1_19_R2/pom.xml
+++ b/1_19_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R2</artifactId>

--- a/1_19_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_19_R2.java
+++ b/1_19_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_19_R2.java
@@ -44,8 +44,8 @@ public final class Wrapper1_19_R2 implements VersionWrapper {
     }
 
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId, String inventoryTitle) {
-        toNMS(player).b.a(new PacketPlayOutOpenWindow(containerId, Containers.h, IChatBaseComponent.a(inventoryTitle)));
+    public void sendPacketOpenWindow(Player player, int containerId, Object inventoryTitle) {
+        toNMS(player).b.a(new PacketPlayOutOpenWindow(containerId, Containers.h, (IChatBaseComponent) inventoryTitle));
     }
 
     @Override
@@ -77,18 +77,28 @@ public final class Wrapper1_19_R2 implements VersionWrapper {
     }
 
     @Override
-    public Object newContainerAnvil(Player player, String title) {
-        return new AnvilContainer(player, getRealNextContainerId(player), title);
+    public Object newContainerAnvil(Player player, Object title) {
+        return new AnvilContainer(player, getRealNextContainerId(player), (IChatBaseComponent) title);
+    }
+
+    @Override
+    public Object literalChatComponent(String content) {
+        return IChatBaseComponent.b(content);
+    }
+
+    @Override
+    public Object jsonChatComponent(String json) {
+        return IChatBaseComponent.ChatSerializer.a(json);
     }
 
     private static class AnvilContainer extends ContainerAnvil {
-        public AnvilContainer(Player player, int containerId, String guiTitle) {
+        public AnvilContainer(Player player, int containerId, IChatBaseComponent guiTitle) {
             super(
                     containerId,
                     ((CraftPlayer) player).getHandle().fE(),
                     ContainerAccess.a(((CraftWorld) player.getWorld()).getHandle(), new BlockPosition(0, 0, 0)));
             this.checkReachable = false;
-            setTitle(IChatBaseComponent.a(guiTitle));
+            setTitle(guiTitle);
         }
 
         @Override

--- a/1_19_R3/pom.xml
+++ b/1_19_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R3</artifactId>

--- a/1_19_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_19_R3.java
+++ b/1_19_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_19_R3.java
@@ -44,8 +44,8 @@ public final class Wrapper1_19_R3 implements VersionWrapper {
     }
 
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId, String inventoryTitle) {
-        toNMS(player).b.a(new PacketPlayOutOpenWindow(containerId, Containers.h, IChatBaseComponent.a(inventoryTitle)));
+    public void sendPacketOpenWindow(Player player, int containerId, Object inventoryTitle) {
+        toNMS(player).b.a(new PacketPlayOutOpenWindow(containerId, Containers.h, (IChatBaseComponent) inventoryTitle));
     }
 
     @Override
@@ -77,18 +77,28 @@ public final class Wrapper1_19_R3 implements VersionWrapper {
     }
 
     @Override
-    public Object newContainerAnvil(Player player, String title) {
-        return new AnvilContainer(player, getRealNextContainerId(player), title);
+    public Object newContainerAnvil(Player player, Object title) {
+        return new AnvilContainer(player, getRealNextContainerId(player), (IChatBaseComponent) title);
+    }
+
+    @Override
+    public Object literalChatComponent(String content) {
+        return IChatBaseComponent.b(content);
+    }
+
+    @Override
+    public Object jsonChatComponent(String json) {
+        return IChatBaseComponent.ChatSerializer.a(json);
     }
 
     private static class AnvilContainer extends ContainerAnvil {
-        public AnvilContainer(Player player, int containerId, String guiTitle) {
+        public AnvilContainer(Player player, int containerId, IChatBaseComponent guiTitle) {
             super(
                     containerId,
                     ((CraftPlayer) player).getHandle().fJ(),
                     ContainerAccess.a(((CraftWorld) player.getWorld()).getHandle(), new BlockPosition(0, 0, 0)));
             this.checkReachable = false;
-            setTitle(IChatBaseComponent.a(guiTitle));
+            setTitle(guiTitle);
         }
 
         @Override

--- a/1_20_R1/pom.xml
+++ b/1_20_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_20_R1</artifactId>

--- a/1_20_R1/src/main/java/net.wesjd.anvilgui.version/Wrapper1_20_R1.java
+++ b/1_20_R1/src/main/java/net.wesjd.anvilgui.version/Wrapper1_20_R1.java
@@ -44,8 +44,8 @@ public final class Wrapper1_20_R1 implements VersionWrapper {
     }
 
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId, String inventoryTitle) {
-        toNMS(player).c.a(new PacketPlayOutOpenWindow(containerId, Containers.h, IChatBaseComponent.a(inventoryTitle)));
+    public void sendPacketOpenWindow(Player player, int containerId, Object inventoryTitle) {
+        toNMS(player).c.a(new PacketPlayOutOpenWindow(containerId, Containers.h, (IChatBaseComponent) inventoryTitle));
     }
 
     @Override
@@ -77,18 +77,28 @@ public final class Wrapper1_20_R1 implements VersionWrapper {
     }
 
     @Override
-    public Object newContainerAnvil(Player player, String title) {
+    public Object newContainerAnvil(Player player, Object title) {
         return new AnvilContainer(player, getRealNextContainerId(player), title);
     }
 
+    @Override
+    public Object literalChatComponent(String content) {
+        return IChatBaseComponent.b(content);
+    }
+
+    @Override
+    public Object jsonChatComponent(String json) {
+        return IChatBaseComponent.ChatSerializer.a(json);
+    }
+
     private static class AnvilContainer extends ContainerAnvil {
-        public AnvilContainer(Player player, int containerId, String guiTitle) {
+        public AnvilContainer(Player player, int containerId, Object guiTitle) {
             super(
                     containerId,
                     ((CraftPlayer) player).getHandle().fN(),
                     ContainerAccess.a(((CraftWorld) player.getWorld()).getHandle(), new BlockPosition(0, 0, 0)));
             this.checkReachable = false;
-            setTitle(IChatBaseComponent.a(guiTitle));
+            setTitle((IChatBaseComponent) guiTitle);
         }
 
         @Override

--- a/1_20_R1/src/main/java/net.wesjd.anvilgui.version/Wrapper1_20_R1.java
+++ b/1_20_R1/src/main/java/net.wesjd.anvilgui.version/Wrapper1_20_R1.java
@@ -78,7 +78,7 @@ public final class Wrapper1_20_R1 implements VersionWrapper {
 
     @Override
     public Object newContainerAnvil(Player player, Object title) {
-        return new AnvilContainer(player, getRealNextContainerId(player), title);
+        return new AnvilContainer(player, getRealNextContainerId(player), (IChatBaseComponent) title);
     }
 
     @Override
@@ -92,13 +92,13 @@ public final class Wrapper1_20_R1 implements VersionWrapper {
     }
 
     private static class AnvilContainer extends ContainerAnvil {
-        public AnvilContainer(Player player, int containerId, Object guiTitle) {
+        public AnvilContainer(Player player, int containerId, IChatBaseComponent guiTitle) {
             super(
                     containerId,
                     ((CraftPlayer) player).getHandle().fN(),
                     ContainerAccess.a(((CraftWorld) player.getWorld()).getHandle(), new BlockPosition(0, 0, 0)));
             this.checkReachable = false;
-            setTitle((IChatBaseComponent) guiTitle);
+            setTitle(guiTitle);
         }
 
         @Override

--- a/1_7_R4/pom.xml
+++ b/1_7_R4/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_7_R4</artifactId>

--- a/1_7_R4/src/main/java/net/wesjd/anvilgui/version/Wrapper1_7_R4.java
+++ b/1_7_R4/src/main/java/net/wesjd/anvilgui/version/Wrapper1_7_R4.java
@@ -36,9 +36,8 @@ public class Wrapper1_7_R4 implements VersionWrapper {
      */
     @Override
     public void sendPacketOpenWindow(final Player player, final int containerId, final Object guiTitle) {
-        this.toNMS(player)
-                .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(containerId, 8, (String) guiTitle, 9, true));
+        this.toNMS(player).playerConnection.sendPacket(new PacketPlayOutOpenWindow(containerId, 8, "", 9, false));
+        // Passing false as the last parameter instructs the client to use an internal title
     }
 
     /**
@@ -99,12 +98,12 @@ public class Wrapper1_7_R4 implements VersionWrapper {
 
     @Override
     public Object literalChatComponent(String content) {
-        return content;
+        return null;
     }
 
     @Override
     public Object jsonChatComponent(String json) {
-        throw new UnsupportedOperationException("Rich text components are only available from Minecraft 1.8 and up");
+        return null;
     }
 
     /**

--- a/1_7_R4/src/main/java/net/wesjd/anvilgui/version/Wrapper1_7_R4.java
+++ b/1_7_R4/src/main/java/net/wesjd/anvilgui/version/Wrapper1_7_R4.java
@@ -35,10 +35,10 @@ public class Wrapper1_7_R4 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(final Player player, final int containerId, final String guiTitle) {
+    public void sendPacketOpenWindow(final Player player, final int containerId, final Object guiTitle) {
         this.toNMS(player)
                 .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(containerId, 8, "Repairing", 9, true));
+                .sendPacket(new PacketPlayOutOpenWindow(containerId, 8, (String) guiTitle, 9, true));
     }
 
     /**
@@ -93,8 +93,18 @@ public class Wrapper1_7_R4 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(final Player player, final String guiTitle) {
+    public Object newContainerAnvil(final Player player, final Object guiTitle) {
         return new AnvilContainer(this.toNMS(player));
+    }
+
+    @Override
+    public Object literalChatComponent(String content) {
+        return content;
+    }
+
+    @Override
+    public Object jsonChatComponent(String json) {
+        throw new UnsupportedOperationException("Rich text components are only available from Minecraft 1.8 and up");
     }
 
     /**

--- a/1_8_R1/pom.xml
+++ b/1_8_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R1</artifactId>

--- a/1_8_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R1.java
+++ b/1_8_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R1.java
@@ -35,11 +35,10 @@ public class Wrapper1_8_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
+    public void sendPacketOpenWindow(Player player, int containerId, Object guiTitle) {
         toNMS(player)
                 .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(
-                        containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
+                .sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", (IChatBaseComponent) guiTitle));
     }
 
     /**
@@ -94,8 +93,18 @@ public class Wrapper1_8_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player, String guiTitle) {
+    public Object newContainerAnvil(Player player, Object guiTitle) {
         return new AnvilContainer(toNMS(player));
+    }
+
+    @Override
+    public Object literalChatComponent(String content) {
+        return new ChatComponentText(content);
+    }
+
+    @Override
+    public Object jsonChatComponent(String json) {
+        return ChatSerializer.a(json);
     }
 
     /**

--- a/1_8_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R1.java
+++ b/1_8_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R1.java
@@ -38,7 +38,8 @@ public class Wrapper1_8_R1 implements VersionWrapper {
     public void sendPacketOpenWindow(Player player, int containerId, Object guiTitle) {
         toNMS(player)
                 .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", (IChatBaseComponent) guiTitle));
+                .sendPacket(new PacketPlayOutOpenWindow(
+                        containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
     }
 
     /**
@@ -99,12 +100,12 @@ public class Wrapper1_8_R1 implements VersionWrapper {
 
     @Override
     public Object literalChatComponent(String content) {
-        return new ChatComponentText(content);
+        return null;
     }
 
     @Override
     public Object jsonChatComponent(String json) {
-        return ChatSerializer.a(json);
+        return null;
     }
 
     /**

--- a/1_8_R2/pom.xml
+++ b/1_8_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R2</artifactId>

--- a/1_8_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R2.java
+++ b/1_8_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R2.java
@@ -38,7 +38,8 @@ public class Wrapper1_8_R2 implements VersionWrapper {
     public void sendPacketOpenWindow(Player player, int containerId, Object guiTitle) {
         toNMS(player)
                 .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", (IChatBaseComponent) guiTitle));
+                .sendPacket(new PacketPlayOutOpenWindow(
+                        containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
     }
 
     /**
@@ -99,12 +100,12 @@ public class Wrapper1_8_R2 implements VersionWrapper {
 
     @Override
     public Object literalChatComponent(String content) {
-        return new ChatComponentText(content);
+        return null;
     }
 
     @Override
     public Object jsonChatComponent(String json) {
-        return IChatBaseComponent.ChatSerializer.a(json);
+        return null;
     }
 
     /**

--- a/1_8_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R2.java
+++ b/1_8_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R2.java
@@ -35,11 +35,10 @@ public class Wrapper1_8_R2 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
+    public void sendPacketOpenWindow(Player player, int containerId, Object guiTitle) {
         toNMS(player)
                 .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(
-                        containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
+                .sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", (IChatBaseComponent) guiTitle));
     }
 
     /**
@@ -94,8 +93,18 @@ public class Wrapper1_8_R2 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player, String guiTitle) {
+    public Object newContainerAnvil(Player player, Object guiTitle) {
         return new AnvilContainer(toNMS(player));
+    }
+
+    @Override
+    public Object literalChatComponent(String content) {
+        return new ChatComponentText(content);
+    }
+
+    @Override
+    public Object jsonChatComponent(String json) {
+        return IChatBaseComponent.ChatSerializer.a(json);
     }
 
     /**

--- a/1_8_R3/pom.xml
+++ b/1_8_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R3</artifactId>

--- a/1_8_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R3.java
+++ b/1_8_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R3.java
@@ -38,7 +38,8 @@ public class Wrapper1_8_R3 implements VersionWrapper {
     public void sendPacketOpenWindow(Player player, int containerId, Object guiTitle) {
         toNMS(player)
                 .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", (IChatBaseComponent) guiTitle));
+                .sendPacket(new PacketPlayOutOpenWindow(
+                        containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
     }
 
     /**
@@ -99,12 +100,12 @@ public class Wrapper1_8_R3 implements VersionWrapper {
 
     @Override
     public Object literalChatComponent(String content) {
-        return new ChatComponentText(content);
+        return null;
     }
 
     @Override
     public Object jsonChatComponent(String json) {
-        return IChatBaseComponent.ChatSerializer.a(json);
+        return null;
     }
 
     /**

--- a/1_8_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R3.java
+++ b/1_8_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R3.java
@@ -35,11 +35,10 @@ public class Wrapper1_8_R3 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
+    public void sendPacketOpenWindow(Player player, int containerId, Object guiTitle) {
         toNMS(player)
                 .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(
-                        containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
+                .sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", (IChatBaseComponent) guiTitle));
     }
 
     /**
@@ -94,8 +93,18 @@ public class Wrapper1_8_R3 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player, String guiTitle) {
+    public Object newContainerAnvil(Player player, Object guiTitle) {
         return new AnvilContainer(toNMS(player));
+    }
+
+    @Override
+    public Object literalChatComponent(String content) {
+        return new ChatComponentText(content);
+    }
+
+    @Override
+    public Object jsonChatComponent(String json) {
+        return IChatBaseComponent.ChatSerializer.a(json);
     }
 
     /**

--- a/1_9_R1/pom.xml
+++ b/1_9_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_9_R1</artifactId>

--- a/1_9_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R1.java
+++ b/1_9_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R1.java
@@ -38,7 +38,8 @@ public class Wrapper1_9_R1 implements VersionWrapper {
     public void sendPacketOpenWindow(Player player, int containerId, Object guiTitle) {
         toNMS(player)
                 .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", (IChatBaseComponent) guiTitle));
+                .sendPacket(new PacketPlayOutOpenWindow(
+                        containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
     }
 
     /**
@@ -99,12 +100,12 @@ public class Wrapper1_9_R1 implements VersionWrapper {
 
     @Override
     public Object literalChatComponent(String content) {
-        return new ChatComponentText(content);
+        return null;
     }
 
     @Override
     public Object jsonChatComponent(String json) {
-        return IChatBaseComponent.ChatSerializer.a(json);
+        return null;
     }
 
     /**

--- a/1_9_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R1.java
+++ b/1_9_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R1.java
@@ -35,11 +35,10 @@ public class Wrapper1_9_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
+    public void sendPacketOpenWindow(Player player, int containerId, Object guiTitle) {
         toNMS(player)
                 .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(
-                        containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
+                .sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", (IChatBaseComponent) guiTitle));
     }
 
     /**
@@ -94,8 +93,18 @@ public class Wrapper1_9_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player, String guiTitle) {
+    public Object newContainerAnvil(Player player, Object guiTitle) {
         return new AnvilContainer(toNMS(player));
+    }
+
+    @Override
+    public Object literalChatComponent(String content) {
+        return new ChatComponentText(content);
+    }
+
+    @Override
+    public Object jsonChatComponent(String json) {
+        return IChatBaseComponent.ChatSerializer.a(json);
     }
 
     /**

--- a/1_9_R2/pom.xml
+++ b/1_9_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_9_R2</artifactId>

--- a/1_9_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R2.java
+++ b/1_9_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R2.java
@@ -38,7 +38,8 @@ public class Wrapper1_9_R2 implements VersionWrapper {
     public void sendPacketOpenWindow(Player player, int containerId, Object guiTitle) {
         toNMS(player)
                 .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", (IChatBaseComponent) guiTitle));
+                .sendPacket(new PacketPlayOutOpenWindow(
+                        containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
     }
 
     /**
@@ -99,12 +100,12 @@ public class Wrapper1_9_R2 implements VersionWrapper {
 
     @Override
     public Object literalChatComponent(String content) {
-        return new ChatComponentText(content);
+        return null;
     }
 
     @Override
     public Object jsonChatComponent(String json) {
-        return IChatBaseComponent.ChatSerializer.a(json);
+        return null;
     }
 
     /**

--- a/1_9_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R2.java
+++ b/1_9_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R2.java
@@ -35,11 +35,10 @@ public class Wrapper1_9_R2 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public void sendPacketOpenWindow(Player player, int containerId, String guiTitle) {
+    public void sendPacketOpenWindow(Player player, int containerId, Object guiTitle) {
         toNMS(player)
                 .playerConnection
-                .sendPacket(new PacketPlayOutOpenWindow(
-                        containerId, "minecraft:anvil", new ChatMessage(Blocks.ANVIL.a() + ".name")));
+                .sendPacket(new PacketPlayOutOpenWindow(containerId, "minecraft:anvil", (IChatBaseComponent) guiTitle));
     }
 
     /**
@@ -94,8 +93,18 @@ public class Wrapper1_9_R2 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
-    public Object newContainerAnvil(Player player, String guiTitle) {
+    public Object newContainerAnvil(Player player, Object guiTitle) {
         return new AnvilContainer(toNMS(player));
+    }
+
+    @Override
+    public Object literalChatComponent(String content) {
+        return new ChatComponentText(content);
+    }
+
+    @Override
+    public Object jsonChatComponent(String json) {
+        return IChatBaseComponent.ChatSerializer.a(json);
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -3,20 +3,20 @@ AnvilGUI is a library to capture user input in Minecraft through an anvil invent
 of the Minecraft / Bukkit / Spigot / Paper API are extremely finnicky and ultimately don't support the ability to use them fully for
 the task of user input. As a result, the only way to achieve user input with an anvil inventory requires interaction with obfuscated,
 decompiled code. AnvilGUI provides a straightforward, versatile, and easy-to-use solution without having your project
-depend on version specific code. 
+depend on version specific code.
 
 ## Requirements
 Java 8 and Bukkit / Spigot. Most server versions in the [Spigot Repository](https://hub.spigotmc.org/nexus/) are supported.
 
 ### My version isn't supported
 If you are a developer, submit a pull request adding a wrapper module for your version. Otherwise, please create an issue
-on the issues tab. 
+on the issues tab.
 
 ## Usage
 
 ### As a dependency
 
-AnvilGUI requires the usage of Maven or a Maven compatible build system. 
+AnvilGUI requires the usage of Maven or a Maven compatible build system.
 ```xml
 <dependency>
     <groupId>net.wesjd</groupId>
@@ -30,7 +30,7 @@ AnvilGUI requires the usage of Maven or a Maven compatible build system.
 </repository>
 ```
 
-It is best to be a good citizen and relocate the dependency to within your namespace in order 
+It is best to be a good citizen and relocate the dependency to within your namespace in order
 to prevent conflicts with other plugins. Here is an example of how to relocate the dependency:
 ```xml
 <build>
@@ -60,7 +60,7 @@ to prevent conflicts with other plugins. Here is an example of how to relocate t
                                     <include>[YOUR_PLUGIN_PACKAGE].anvilgui</include>
                                 </includes>
                             </filter>
-                        </filters> 
+                        </filters>
                     </configuration>
                 </execution>
             </executions>
@@ -73,19 +73,19 @@ ensure that your `<filters>` section contains the example `<filter>` as seen abo
 
 ### In your plugin
 
-The `AnvilGUI.Builder` class is how you build an AnvilGUI. 
+The `AnvilGUI.Builder` class is how you build an AnvilGUI.
 The following methods allow you to modify various parts of the displayed GUI. Javadocs are available [here](http://docs.wesjd.net/AnvilGUI/).
 
-#### `onClose(Consumer<StateSnapshot>)` 
+#### `onClose(Consumer<StateSnapshot>)`
 Takes a `Consumer<StateSnapshot>` argument that is called when a player closes the anvil gui.
-```java                                             
-builder.onClose(stateSnapshot -> {                         
+```java
+builder.onClose(stateSnapshot -> {
     stateSnapshot.getPlayer().sendMessage("You closed the inventory.");
-});                                                 
-``` 
+});
+```
 
 #### `onClick(BiFunction<Integer, AnvilGUI.StateSnapshot, AnvilGUI.ResponseAction>)`
-Takes a `BiFunction` with the slot that was clicked and a snapshot of the current gui state. 
+Takes a `BiFunction` with the slot that was clicked and a snapshot of the current gui state.
 The function is called when a player clicks any slots in the inventory.
 You must return a `List<AnvilGUI.ResponseAction>`, which could include:
 - Closing the inventory (`AnvilGUI.ResponseAction.close()`)
@@ -95,22 +95,22 @@ You must return a `List<AnvilGUI.ResponseAction>`, which could include:
 - Nothing! (`Collections.emptyList()`)
 
 The list of actions are ran in the order they are supplied.
-```java                                                
+```java
 builder.onClick((slot, stateSnapshot) -> {
     if (slot != AnvilGUI.Slot.OUTPUT) {
         return Collections.emptyList();
-    }   
-    
+    }
+
     if (stateSnapshot.getText().equalsIgnoreCase("you")) {
         stateSnapshot.getPlayer().sendMessage("You have magical powers!");
         return Arrays.asList(
             AnvilGUI.ResponseAction.close(),
             AnvilGUI.ResponseAction.run(() -> myCode(stateSnapshot.getPlayer()))
-        );              
-    } else {                                           
-        return Arrays.asList(AnvilGUI.ResponseAction.replaceInputText("Try again"));   
-    }                                                  
-});                                                    
+        );
+    } else {
+        return Arrays.asList(AnvilGUI.ResponseAction.replaceInputText("Try again"));
+    }
+});
 ```
 
 #### `onClickAsync(ClickHandler)`
@@ -124,7 +124,7 @@ builder.onClickAsync((slot, stateSnapshot) -> CompletedFuture.supplyAsync(() -> 
     if (slot != AnvilGUI.Slot.OUTPUT) {
         return Collections.emptyList();
     }
-    
+
     if (database.isMagical(stateSnapshot.getText())) {
         // the `ResponseAction`s will run on the main server thread
         return Arrays.asList(
@@ -140,8 +140,8 @@ builder.onClickAsync((slot, stateSnapshot) -> CompletedFuture.supplyAsync(() -> 
 #### `allowConcurrentClickHandlerExecution()`
 Tells the AnvilGUI to disable the mechanism that is put into place to prevent concurrent execution of the
 click handler set by `onClickAsync(ClickHandler)`.
-```java                     
-builder.allowConcurrentClickHandlerExecution();     
+```java
+builder.allowConcurrentClickHandlerExecution();
 ```
 
 #### `interactableSlots(int... slots)`
@@ -150,46 +150,46 @@ This allows or denies users to take / input items in the anvil slots that are pr
 builder.interactableSlots(Slot.INPUT_LEFT, Slot.INPUT_RIGHT);
 ```
 
-#### `preventClose()` 
+#### `preventClose()`
 Tells the AnvilGUI to prevent the user from pressing escape to close the inventory.
-Useful for situations like password input to play.                                      
-```java                     
-builder.preventClose();     
-```                     
-     
+Useful for situations like password input to play.
+```java
+builder.preventClose();
+```
+
 #### `text(String)`
 Takes a `String` that contains what the initial text in the renaming field should be set to.
 If `itemLeft` is provided, then the display name is set to the provided text. If no `itemLeft`
 is set, then a piece of paper will be used.
-```java                                           
-builder.text("What is the meaning of life?");     
-```  
+```java
+builder.text("What is the meaning of life?");
+```
 
 #### `itemLeft(ItemStack)`
 Takes a custom `ItemStack` to be placed in the left input slot.
-```java                                              
+```java
 ItemStack stack = new ItemStack(Material.IRON_SWORD);
-ItemMeta meta = stack.getItemMeta();                 
-meta.setLore(Arrays.asList("Sharp iron sword"));             
-stack.setItemMeta(meta); 
-builder.itemLeft(stack);        
-```         
+ItemMeta meta = stack.getItemMeta();
+meta.setLore(Arrays.asList("Sharp iron sword"));
+stack.setItemMeta(meta);
+builder.itemLeft(stack);
+```
 
 #### `itemRight(ItemStack)`
 Takes a custom `ItemStack` to be placed in the right input slot.
-```java                                              
+```java
 ItemStack stack = new ItemStack(Material.IRON_INGOT);
-ItemMeta meta = stack.getItemMeta();                 
-meta.setLore(Arrays.asList("A piece of metal"));             
-stack.setItemMeta(meta); 
-builder.itemRight(stack);        
-```         
+ItemMeta meta = stack.getItemMeta();
+meta.setLore(Arrays.asList("A piece of metal"));
+stack.setItemMeta(meta);
+builder.itemRight(stack);
+```
 
 #### `title(String)`
 Takes a `String` that will be used literally as the inventory title. Only displayed in Minecraft 1.14 and above.
-```java                            
+```java
 builder.title("Enter your answer");
-```                                
+```
 
 #### `jsonTitle(String)`
 Takes a `String` which contains rich text components serialized as JSON.
@@ -198,12 +198,12 @@ Only displayed in Minecraft 1.14 and above.
 ```java
 builder.jsonTitle("{\"text\":\"Enter your answer\",\"color\":\"green\"}")
 ```
-                 
+
 #### `plugin(Plugin)`
 Takes the `Plugin` object that is making this anvil gui. It is needed to register listeners.
-```java                                         
-builder.plugin(pluginInstance);                 
-```                            
+```java
+builder.plugin(pluginInstance);
+```
 
 #### `mainThreadExecutor(Executor)`
 Takes an `Executor` that must execute on the main server thread.
@@ -215,10 +215,10 @@ builder.mainThreadExecutor(executor);
 
 #### `open(Player)`
 Takes a `Player` that the anvil gui should be opened for. This method can be called multiple times without needing to create
-a new `AnvilGUI.Builder` object.                                                                                            
-```java              
+a new `AnvilGUI.Builder` object.
+```java
 builder.open(player);
-```                  
+```
 
 ### A Common Use Case Example
 ```java
@@ -244,9 +244,9 @@ new AnvilGUI.Builder()
     .plugin(myPluginInstance)                                          //set the plugin instance
     .open(myPlayer);                                                   //opens the GUI for the player provided
 ```
-                                                                                                                                                                                                                                                                              
 
-## Development 
+
+## Development
 We use Maven to handle our dependencies. Run `mvn clean install` using Java 17 to build the project.
 
 ### Spotless

--- a/README.md
+++ b/README.md
@@ -186,10 +186,18 @@ builder.itemRight(stack);
 ```         
 
 #### `title(String)`
-Takes a `String` that will be used as the inventory title. Only displayed in Minecraft 1.14 and above.
+Takes a `String` that will be used literally as the inventory title. Only displayed in Minecraft 1.14 and above.
 ```java                            
 builder.title("Enter your answer");
 ```                                
+
+#### `jsonTitle(String)`
+Takes a `String` which contains rich text components serialized as JSON.
+Useful for settings titles with hex color codes or Adventure Component interop.
+Only displayed in Minecraft 1.14 and above.
+```java
+builder.jsonTitle("{\"text\":\"Enter your answer\",\"color\":\"green\"}")
+```
                  
 #### `plugin(Plugin)`
 Takes the `Plugin` object that is making this anvil gui. It is needed to register listeners.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ AnvilGUI requires the usage of Maven or a Maven compatible build system.
 <dependency>
     <groupId>net.wesjd</groupId>
     <artifactId>anvilgui</artifactId>
-    <version>1.6.6-SNAPSHOT</version>
+    <version>1.7.0-SNAPSHOT</version>
 </dependency>
 
 <repository>

--- a/abstraction/pom.xml
+++ b/abstraction/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-abstraction</artifactId>

--- a/abstraction/src/main/java/net/wesjd/anvilgui/version/VersionWrapper.java
+++ b/abstraction/src/main/java/net/wesjd/anvilgui/version/VersionWrapper.java
@@ -93,7 +93,19 @@ public interface VersionWrapper {
      */
     Object newContainerAnvil(Player player, Object title);
 
+    /**
+     * Creates a new chat component that does not handle the content in any special way
+     *
+     * @param content The content to display
+     * @return Version-specific ChatComponent instance
+     */
     Object literalChatComponent(String content);
 
+    /**
+     * Creates a new rich chat component from the provided json
+     *
+     * @param json The component to parse
+     * @return Version-specific ChatComponent instance
+     */
     Object jsonChatComponent(String json);
 }

--- a/abstraction/src/main/java/net/wesjd/anvilgui/version/VersionWrapper.java
+++ b/abstraction/src/main/java/net/wesjd/anvilgui/version/VersionWrapper.java
@@ -35,7 +35,7 @@ public interface VersionWrapper {
      * @param containerId    The container id to open
      * @param inventoryTitle The title of the inventory to be opened (only works in Minecraft 1.14 and above)
      */
-    void sendPacketOpenWindow(Player player, int containerId, String inventoryTitle);
+    void sendPacketOpenWindow(Player player, int containerId, Object inventoryTitle);
 
     /**
      * Sends PacketPlayOutCloseWindow to the player with the contaienr id
@@ -91,5 +91,9 @@ public interface VersionWrapper {
      * @param title  The title of the anvil inventory
      * @return The Container instance
      */
-    Object newContainerAnvil(Player player, String title);
+    Object newContainerAnvil(Player player, Object title);
+
+    Object literalChatComponent(String content);
+
+    Object jsonChatComponent(String json);
 }

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -25,7 +25,7 @@
             <version>${project.parent.version}</version>
             <scope>compile</scope>
         </dependency>
-        <dependency>
+        <!--dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_7_R4</artifactId>
             <version>${project.parent.version}</version>
@@ -174,7 +174,7 @@
             <artifactId>anvilgui-1_19_R3</artifactId>
             <version>${project.parent.version}</version>
             <scope>compile</scope>
-        </dependency>
+        </dependency-->
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_20_R1</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -25,7 +25,7 @@
             <version>${project.parent.version}</version>
             <scope>compile</scope>
         </dependency>
-        <!--dependency>
+        <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_7_R4</artifactId>
             <version>${project.parent.version}</version>
@@ -174,7 +174,7 @@
             <artifactId>anvilgui-1_19_R3</artifactId>
             <version>${project.parent.version}</version>
             <scope>compile</scope>
-        </dependency-->
+        </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_20_R1</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.6.6-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui</artifactId>

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -495,7 +495,6 @@ public class AnvilGUI {
          * @param json The title that is to be displayed to the user
          * @return The {@link Builder} instance
          * @throws IllegalArgumentException if the title is null
-         * @throws UnsupportedOperationException if this method is called on a Minecraft 1.7 server
          */
         public Builder rawTitle(String json) {
             Validate.notNull(json, "json cannot be null");

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -13,6 +13,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.logging.Level;
+import net.md_5.bungee.api.chat.BaseComponent;
 import net.wesjd.anvilgui.version.VersionMatcher;
 import net.wesjd.anvilgui.version.VersionWrapper;
 import org.apache.commons.lang.Validate;
@@ -460,7 +461,10 @@ public class AnvilGUI {
         }
 
         /**
-         * Sets the inital item-text that is displayed to the user
+         * Sets the initial item-text that is displayed to the user.
+         * <br><br>
+         * If the usage of Adventure Components is desired, you must create an item, set the displayname of it
+         * and put it into the AnvilGUI via {@link #itemLeft(ItemStack)} manually.
          *
          * @param text The initial name of the item in the anvil
          * @return The {@link Builder} instance
@@ -495,8 +499,9 @@ public class AnvilGUI {
          * @param json The title that is to be displayed to the user
          * @return The {@link Builder} instance
          * @throws IllegalArgumentException if the title is null
+         * @see net.md_5.bungee.chat.ComponentSerializer#toString(BaseComponent)
          */
-        public Builder rawTitle(String json) {
+        public Builder jsonTitle(String json) {
             Validate.notNull(json, "json cannot be null");
             this.titleComponent = WRAPPER.jsonChatComponent(json);
             return this;

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -71,7 +71,7 @@ public class AnvilGUI {
     /**
      * The title of the anvil inventory
      */
-    private final String inventoryTitle;
+    private final Object inventoryTitle;
     /**
      * The initial contents of the inventory
      */
@@ -131,7 +131,7 @@ public class AnvilGUI {
             Plugin plugin,
             Player player,
             Executor mainThreadExecutor,
-            String inventoryTitle,
+            Object inventoryTitle,
             ItemStack[] initialContents,
             boolean preventClose,
             Set<Integer> interactableSlots,
@@ -332,7 +332,7 @@ public class AnvilGUI {
         /** The {@link Plugin} that this anvil GUI is associated with */
         private Plugin plugin;
         /** The text that will be displayed to the user */
-        private String title = "Repair & Name";
+        private Object title = WRAPPER.literalChatComponent("Repair & Name");
         /** The starting text on the item */
         private String itemText;
         /** An {@link ItemStack} to be put in the left input slot */
@@ -481,7 +481,13 @@ public class AnvilGUI {
          */
         public Builder title(String title) {
             Validate.notNull(title, "title cannot be null");
-            this.title = title;
+            this.title = WRAPPER.literalChatComponent(title);
+            return this;
+        }
+
+        public Builder rawTitle(String json) {
+            Validate.notNull(json, "json cannot be null");
+            this.title = WRAPPER.jsonChatComponent(json);
             return this;
         }
 

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -71,7 +71,7 @@ public class AnvilGUI {
     /**
      * The title of the anvil inventory
      */
-    private final Object inventoryTitle;
+    private final Object titleComponent;
     /**
      * The initial contents of the inventory
      */
@@ -120,7 +120,7 @@ public class AnvilGUI {
      * @param plugin           A {@link org.bukkit.plugin.java.JavaPlugin} instance
      * @param player           The {@link Player} to open the inventory for
      * @param mainThreadExecutor An {@link Executor} that executes on the main server thread
-     * @param inventoryTitle   What to have the text already set to
+     * @param titleComponent   What to have the text already set to
      * @param initialContents  The initial contents of the inventory
      * @param preventClose     Whether to prevent the inventory from closing
      * @param closeListener    A {@link Consumer} when the inventory closes
@@ -131,7 +131,7 @@ public class AnvilGUI {
             Plugin plugin,
             Player player,
             Executor mainThreadExecutor,
-            Object inventoryTitle,
+            Object titleComponent,
             ItemStack[] initialContents,
             boolean preventClose,
             Set<Integer> interactableSlots,
@@ -141,7 +141,7 @@ public class AnvilGUI {
         this.plugin = plugin;
         this.player = player;
         this.mainThreadExecutor = mainThreadExecutor;
-        this.inventoryTitle = inventoryTitle;
+        this.titleComponent = titleComponent;
         this.initialContents = initialContents;
         this.preventClose = preventClose;
         this.interactableSlots = Collections.unmodifiableSet(interactableSlots);
@@ -159,7 +159,7 @@ public class AnvilGUI {
 
         Bukkit.getPluginManager().registerEvents(listener, plugin);
 
-        final Object container = WRAPPER.newContainerAnvil(player, inventoryTitle);
+        final Object container = WRAPPER.newContainerAnvil(player, titleComponent);
 
         inventory = WRAPPER.toBukkitInventory(container);
         // We need to use setItem instead of setContents because a Minecraft ContainerAnvil
@@ -171,7 +171,7 @@ public class AnvilGUI {
         }
 
         containerId = WRAPPER.getNextContainerId(player, container);
-        WRAPPER.sendPacketOpenWindow(player, containerId, inventoryTitle);
+        WRAPPER.sendPacketOpenWindow(player, containerId, titleComponent);
         WRAPPER.setActiveContainer(player, container);
         WRAPPER.setActiveContainerId(container, containerId);
         WRAPPER.addActiveContainerSlotListener(container, player);
@@ -332,7 +332,7 @@ public class AnvilGUI {
         /** The {@link Plugin} that this anvil GUI is associated with */
         private Plugin plugin;
         /** The text that will be displayed to the user */
-        private Object title = WRAPPER.literalChatComponent("Repair & Name");
+        private Object titleComponent = WRAPPER.literalChatComponent("Repair & Name");
         /** The starting text on the item */
         private String itemText;
         /** An {@link ItemStack} to be put in the left input slot */
@@ -473,7 +473,9 @@ public class AnvilGUI {
         }
 
         /**
-         * Sets the AnvilGUI title that is to be displayed to the user
+         * Sets the AnvilGUI title that is to be displayed to the user.
+         * <br>
+         * The provided title will be treated as literal text.
          *
          * @param title The title that is to be displayed to the user
          * @return The {@link Builder} instance
@@ -481,13 +483,23 @@ public class AnvilGUI {
          */
         public Builder title(String title) {
             Validate.notNull(title, "title cannot be null");
-            this.title = WRAPPER.literalChatComponent(title);
+            this.titleComponent = WRAPPER.literalChatComponent(title);
             return this;
         }
 
+        /**
+         * Sets the AnvilGUI title that is to be displayed to the user.
+         * <br>
+         * The provided json will be parsed into rich chat components.
+         *
+         * @param json The title that is to be displayed to the user
+         * @return The {@link Builder} instance
+         * @throws IllegalArgumentException if the title is null
+         * @throws UnsupportedOperationException if this method is called on a Minecraft 1.7 server
+         */
         public Builder rawTitle(String json) {
             Validate.notNull(json, "json cannot be null");
-            this.title = WRAPPER.jsonChatComponent(json);
+            this.titleComponent = WRAPPER.jsonChatComponent(json);
             return this;
         }
 
@@ -557,7 +569,7 @@ public class AnvilGUI {
                     plugin,
                     player,
                     mainThreadExecutor,
-                    title,
+                    titleComponent,
                     new ItemStack[] {itemLeft, itemRight, itemOutput},
                     preventClose,
                     interactableSlots,

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -547,7 +547,7 @@ public class AnvilGUI {
          *
          * @param player The {@link Player} the anvil GUI should open for
          * @return The {@link AnvilGUI} instance from this builder
-         * @throws IllegalArgumentException when the onComplete function, plugin, or player is null
+         * @throws IllegalArgumentException when the onClick function, plugin, or player is null
          */
         public AnvilGUI open(Player player) {
             Validate.notNull(plugin, "Plugin cannot be null");

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.wesjd</groupId>
     <artifactId>anvilgui-parent</artifactId>
-    <version>1.6.6-SNAPSHOT</version>
+    <version>1.7.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <modules>
         <module>api</module>
         <module>abstraction</module>
-        <!--module>1_7_R4</module>
+        <module>1_7_R4</module>
         <module>1_8_R1</module>
         <module>1_8_R2</module>
         <module>1_8_R3</module>
@@ -40,7 +40,7 @@
         <module>1_19_R1</module>
         <module>1_19_1_R1</module>
         <module>1_19_R2</module>
-        <module>1_19_R3</module-->
+        <module>1_19_R3</module>
         <module>1_20_R1</module>
     </modules>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <modules>
         <module>api</module>
         <module>abstraction</module>
-        <module>1_7_R4</module>
+        <!--module>1_7_R4</module>
         <module>1_8_R1</module>
         <module>1_8_R2</module>
         <module>1_8_R3</module>
@@ -40,7 +40,7 @@
         <module>1_19_R1</module>
         <module>1_19_1_R1</module>
         <module>1_19_R2</module>
-        <module>1_19_R3</module>
+        <module>1_19_R3</module-->
         <module>1_20_R1</module>
     </modules>
 


### PR DESCRIPTION
Proof of concept implementation that allows providing raw json components.

This could either be used with Adventure components and `GsonComponentSerializer` or bungeecord-chat's `ComponentSerializer` to serialize hex formatted components into json and then pass them to AnvilGUI

![Screenshot_20230614_172048](https://github.com/WesJD/AnvilGUI/assets/21055143/484c544d-417c-49c5-ba1d-4be3dd521611)

Would fix #269 and somewhat #233 atm

---

Some questions/ideas on the whole thing:
- Are colors on the editable text actually useful? Anvils (to my knowledge) handle text only as plain text.
- If it is still required one could simple create the items manually and use available Paper methods to alter the display name
- We could compile this project Paper on the classpath but implement the methods using adventure in a way that would not break on spigot servers but could be used by plugins running on Paper