### PR TITLE
Allow for arbitrary input and output items

### DIFF
--- a/1_10_R1/pom.xml
+++ b/1_10_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_10_R1</artifactId>

--- a/1_10_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_10_R1.java
+++ b/1_10_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_10_R1.java
@@ -128,6 +128,20 @@ public class Wrapper1_10_R1 implements VersionWrapper {
         }
 
         @Override
+        public void e() {
+            // If the output is empty copy the left input into the output
+            Slot output = this.getSlot(2);
+            if (!output.hasItem()) {
+                output.set(this.getSlot(0).getItem().cloneItemStack());
+            }
+
+            this.a = 0;
+
+            // Sync to the client
+            this.b();
+        }
+
+        @Override
         public boolean a(EntityHuman entityhuman) {
             return true;
         }

--- a/1_11_R1/pom.xml
+++ b/1_11_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_11_R1</artifactId>

--- a/1_11_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_11_R1.java
+++ b/1_11_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_11_R1.java
@@ -128,6 +128,20 @@ public class Wrapper1_11_R1 implements VersionWrapper {
         }
 
         @Override
+        public void e() {
+            // If the output is empty copy the left input into the output
+            Slot output = this.getSlot(2);
+            if (!output.hasItem()) {
+                output.set(this.getSlot(0).getItem().cloneItemStack());
+            }
+
+            this.a = 0;
+
+            // Sync to the client
+            this.b();
+        }
+
+        @Override
         public boolean a(EntityHuman entityhuman) {
             return true;
         }

--- a/1_12_R1/pom.xml
+++ b/1_12_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_12_R1</artifactId>

--- a/1_12_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_12_R1.java
+++ b/1_12_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_12_R1.java
@@ -130,8 +130,16 @@ public class Wrapper1_12_R1 implements VersionWrapper {
 
         @Override
         public void e() {
-            super.e();
+            // If the output is empty copy the left input into the output
+            Slot output = this.getSlot(2);
+            if (!output.hasItem()) {
+                output.set(this.getSlot(0).getItem().cloneItemStack());
+            }
+
             this.levelCost = 0;
+
+            // Sync to the client
+            this.b();
         }
 
         @Override

--- a/1_13_R1/pom.xml
+++ b/1_13_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_13_R1</artifactId>

--- a/1_13_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R1.java
+++ b/1_13_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R1.java
@@ -130,8 +130,16 @@ public class Wrapper1_13_R1 implements VersionWrapper {
 
         @Override
         public void d() {
-            super.d();
+            // If the output is empty copy the left input into the output
+            Slot output = this.getSlot(2);
+            if (!output.hasItem()) {
+                output.set(this.getSlot(0).getItem().cloneItemStack());
+            }
+
             this.levelCost = 0;
+
+            // Sync to the client
+            this.b();
         }
 
         @Override

--- a/1_13_R2/pom.xml
+++ b/1_13_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_13_R2</artifactId>

--- a/1_13_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R2.java
+++ b/1_13_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R2.java
@@ -130,8 +130,16 @@ public class Wrapper1_13_R2 implements VersionWrapper {
 
         @Override
         public void d() {
-            super.d();
+            // If the output is empty copy the left input into the output
+            Slot output = this.getSlot(2);
+            if (!output.hasItem()) {
+                output.set(this.getSlot(0).getItem().cloneItemStack());
+            }
+
             this.levelCost = 0;
+
+            // Sync to the client
+            this.b();
         }
 
         @Override

--- a/1_14_4_R1/pom.xml
+++ b/1_14_4_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_14_4_R1</artifactId>

--- a/1_14_4_R1/src/main/java/net/wesjd/anvilgui/version/special/AnvilContainer1_14_4_R1.java
+++ b/1_14_4_R1/src/main/java/net/wesjd/anvilgui/version/special/AnvilContainer1_14_4_R1.java
@@ -19,8 +19,16 @@ public class AnvilContainer1_14_4_R1 extends ContainerAnvil {
 
     @Override
     public void e() {
-        super.e();
+        // If the output is empty copy the left input into the output
+        Slot output = this.getSlot(2);
+        if (!output.hasItem()) {
+            output.set(this.getSlot(0).getItem().cloneItemStack());
+        }
+
         this.levelCost.set(0);
+
+        // Sync to the client
+        this.c();
     }
 
     @Override

--- a/1_14_R1/pom.xml
+++ b/1_14_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_14_R1</artifactId>

--- a/1_14_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_14_R1.java
+++ b/1_14_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_14_R1.java
@@ -144,8 +144,16 @@ public class Wrapper1_14_R1 implements VersionWrapper {
 
         @Override
         public void e() {
-            super.e();
+            // If the output is empty copy the left input into the output
+            Slot output = this.getSlot(2);
+            if (!output.hasItem()) {
+                output.set(this.getSlot(0).getItem().cloneItemStack());
+            }
+
             this.levelCost.a(0);
+
+            // Sync to the client
+            this.c();
         }
 
         @Override

--- a/1_15_R1/pom.xml
+++ b/1_15_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_15_R1</artifactId>

--- a/1_15_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_15_R1.java
+++ b/1_15_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_15_R1.java
@@ -131,8 +131,16 @@ public class Wrapper1_15_R1 implements VersionWrapper {
 
         @Override
         public void e() {
-            super.e();
+            // If the output is empty copy the left input into the output
+            Slot output = this.getSlot(2);
+            if (!output.hasItem()) {
+                output.set(this.getSlot(0).getItem().cloneItemStack());
+            }
+
             this.levelCost.set(0);
+
+            // Sync to the client
+            this.c();
         }
 
         @Override

--- a/1_16_R1/pom.xml
+++ b/1_16_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R1</artifactId>

--- a/1_16_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R1.java
+++ b/1_16_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R1.java
@@ -131,8 +131,16 @@ public class Wrapper1_16_R1 implements VersionWrapper {
 
         @Override
         public void e() {
-            super.e();
+            // If the output is empty copy the left input into the output
+            Slot output = this.getSlot(2);
+            if (!output.hasItem()) {
+                output.set(this.getSlot(0).getItem().cloneItemStack());
+            }
+
             this.levelCost.set(0);
+
+            // Sync to the client
+            this.c();
         }
 
         @Override

--- a/1_16_R2/pom.xml
+++ b/1_16_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R2</artifactId>

--- a/1_16_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R2.java
+++ b/1_16_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R2.java
@@ -131,8 +131,16 @@ public class Wrapper1_16_R2 implements VersionWrapper {
 
         @Override
         public void e() {
-            super.e();
+            // If the output is empty copy the left input into the output
+            Slot output = this.getSlot(2);
+            if (!output.hasItem()) {
+                output.set(this.getSlot(0).getItem().cloneItemStack());
+            }
+
             this.levelCost.set(0);
+
+            // Sync to the client
+            this.c();
         }
 
         @Override

--- a/1_16_R3/pom.xml
+++ b/1_16_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R3</artifactId>

--- a/1_16_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R3.java
+++ b/1_16_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R3.java
@@ -131,8 +131,16 @@ public class Wrapper1_16_R3 implements VersionWrapper {
 
         @Override
         public void e() {
-            super.e();
+            // If the output is empty copy the left input into the output
+            Slot output = this.getSlot(2);
+            if (!output.hasItem()) {
+                output.set(this.getSlot(0).getItem().cloneItemStack());
+            }
+
             this.levelCost.set(0);
+
+            // Sync to the client
+            this.c();
         }
 
         @Override

--- a/1_17_1_R1/pom.xml
+++ b/1_17_1_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_17_1_R1</artifactId>

--- a/1_17_1_R1/src/main/java/net/wesjd/anvilgui/version/special/AnvilContainer1_17_1_R1.java
+++ b/1_17_1_R1/src/main/java/net/wesjd/anvilgui/version/special/AnvilContainer1_17_1_R1.java
@@ -7,6 +7,7 @@ import net.minecraft.world.IInventory;
 import net.minecraft.world.entity.player.EntityHuman;
 import net.minecraft.world.inventory.ContainerAccess;
 import net.minecraft.world.inventory.ContainerAnvil;
+import net.minecraft.world.inventory.Slot;
 import org.bukkit.craftbukkit.v1_17_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_17_R1.entity.CraftPlayer;
 import org.bukkit.entity.Player;
@@ -23,8 +24,17 @@ public class AnvilContainer1_17_1_R1 extends ContainerAnvil {
 
     @Override
     public void l() {
-        super.l();
+        // If the output is empty copy the left input into the output
+        Slot output = this.getSlot(2);
+        if (!output.hasItem()) {
+            output.set(this.getSlot(0).getItem().cloneItemStack());
+        }
+
         this.w.set(0);
+
+        // Sync to the client
+        this.updateInventory();
+        this.d();
     }
 
     @Override

--- a/1_17_R1/pom.xml
+++ b/1_17_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_17_R1</artifactId>

--- a/1_17_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_17_R1.java
+++ b/1_17_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_17_R1.java
@@ -9,10 +9,7 @@ import net.minecraft.network.protocol.game.PacketPlayOutOpenWindow;
 import net.minecraft.server.level.EntityPlayer;
 import net.minecraft.world.IInventory;
 import net.minecraft.world.entity.player.EntityHuman;
-import net.minecraft.world.inventory.Container;
-import net.minecraft.world.inventory.ContainerAccess;
-import net.minecraft.world.inventory.ContainerAnvil;
-import net.minecraft.world.inventory.Containers;
+import net.minecraft.world.inventory.*;
 import net.wesjd.anvilgui.version.special.AnvilContainer1_17_1_R1;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_17_R1.CraftWorld;
@@ -151,8 +148,20 @@ public class Wrapper1_17_R1 implements VersionWrapper {
 
         @Override
         public void i() {
-            super.i();
+            // If the output is empty copy the left input into the output
+            Slot output = this.getSlot(2);
+            if (!output.hasItem()) {
+                output.set(this.getSlot(0).getItem().cloneItemStack());
+            }
+
             this.w.set(0);
+
+            // Sync to the client
+            // This call has been added in 1.17.1, to fix
+            // https://hub.spigotmc.org/jira/projects/SPIGOT/issues/SPIGOT-6686
+            // but we can backport it here to 1.17
+            this.updateInventory();
+            this.d();
         }
 
         @Override

--- a/1_18_R1/pom.xml
+++ b/1_18_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_18_R1</artifactId>

--- a/1_18_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_18_R1.java
+++ b/1_18_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_18_R1.java
@@ -9,10 +9,7 @@ import net.minecraft.network.protocol.game.PacketPlayOutOpenWindow;
 import net.minecraft.server.level.EntityPlayer;
 import net.minecraft.world.IInventory;
 import net.minecraft.world.entity.player.EntityHuman;
-import net.minecraft.world.inventory.Container;
-import net.minecraft.world.inventory.ContainerAccess;
-import net.minecraft.world.inventory.ContainerAnvil;
-import net.minecraft.world.inventory.Containers;
+import net.minecraft.world.inventory.*;
 import org.bukkit.craftbukkit.v1_18_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_18_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_18_R1.event.CraftEventFactory;
@@ -104,8 +101,17 @@ public final class Wrapper1_18_R1 implements VersionWrapper {
 
         @Override
         public void l() {
-            super.l();
+            // If the output is empty copy the left input into the output
+            Slot output = this.a(2);
+            if (!output.f()) {
+                output.d(this.a(0).e().m());
+            }
+
             this.w.a(0);
+
+            // Sync to the client
+            this.b();
+            this.d();
         }
 
         @Override

--- a/1_18_R2/pom.xml
+++ b/1_18_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_18_R2</artifactId>

--- a/1_18_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_18_R2.java
+++ b/1_18_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_18_R2.java
@@ -9,10 +9,7 @@ import net.minecraft.network.protocol.game.PacketPlayOutOpenWindow;
 import net.minecraft.server.level.EntityPlayer;
 import net.minecraft.world.IInventory;
 import net.minecraft.world.entity.player.EntityHuman;
-import net.minecraft.world.inventory.Container;
-import net.minecraft.world.inventory.ContainerAccess;
-import net.minecraft.world.inventory.ContainerAnvil;
-import net.minecraft.world.inventory.Containers;
+import net.minecraft.world.inventory.*;
 import org.bukkit.craftbukkit.v1_18_R2.CraftWorld;
 import org.bukkit.craftbukkit.v1_18_R2.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_18_R2.event.CraftEventFactory;
@@ -104,8 +101,17 @@ public final class Wrapper1_18_R2 implements VersionWrapper {
 
         @Override
         public void l() {
-            super.l();
+            // If the output is empty copy the left input into the output
+            Slot output = this.b(2);
+            if (!output.f()) {
+                output.d(this.b(0).e().n());
+            }
+
             this.w.a(0);
+
+            // Sync to the client
+            this.b();
+            this.d();
         }
 
         @Override

--- a/1_19_1_R1/pom.xml
+++ b/1_19_1_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_1_R1</artifactId>

--- a/1_19_1_R1/src/main/java/net/wesjd/anvilgui/version/special/AnvilContainer1_19_1_R1.java
+++ b/1_19_1_R1/src/main/java/net/wesjd/anvilgui/version/special/AnvilContainer1_19_1_R1.java
@@ -7,6 +7,7 @@ import net.minecraft.world.IInventory;
 import net.minecraft.world.entity.player.EntityHuman;
 import net.minecraft.world.inventory.ContainerAccess;
 import net.minecraft.world.inventory.ContainerAnvil;
+import net.minecraft.world.inventory.Slot;
 import org.bukkit.craftbukkit.v1_19_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_19_R1.entity.CraftPlayer;
 import org.bukkit.entity.Player;
@@ -23,8 +24,16 @@ public class AnvilContainer1_19_1_R1 extends ContainerAnvil {
 
     @Override
     public void l() {
-        super.l();
+        // If the output is empty copy the left input into the output
+        Slot output = this.b(2);
+        if (!output.f()) {
+            output.e(this.b(0).e().o());
+        }
+
         this.w.a(0);
+        // Sync to the client
+        this.b();
+        this.d();
     }
 
     @Override

--- a/1_19_R1/pom.xml
+++ b/1_19_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R1</artifactId>

--- a/1_19_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_19_R1.java
+++ b/1_19_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_19_R1.java
@@ -8,10 +8,7 @@ import net.minecraft.network.protocol.game.PacketPlayOutOpenWindow;
 import net.minecraft.server.level.EntityPlayer;
 import net.minecraft.world.IInventory;
 import net.minecraft.world.entity.player.EntityHuman;
-import net.minecraft.world.inventory.Container;
-import net.minecraft.world.inventory.ContainerAccess;
-import net.minecraft.world.inventory.ContainerAnvil;
-import net.minecraft.world.inventory.Containers;
+import net.minecraft.world.inventory.*;
 import net.wesjd.anvilgui.version.special.AnvilContainer1_19_1_R1;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_19_R1.CraftWorld;
@@ -114,8 +111,17 @@ public final class Wrapper1_19_R1 implements VersionWrapper {
 
         @Override
         public void l() {
-            super.l();
+            // If the output is empty copy the left input into the output
+            Slot output = this.b(2);
+            if (!output.f()) {
+                output.e(this.b(0).e().o());
+            }
+
             this.w.a(0);
+
+            // Sync to the client
+            this.b();
+            this.d();
         }
 
         @Override

--- a/1_19_R2/pom.xml
+++ b/1_19_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R2</artifactId>

--- a/1_19_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_19_R2.java
+++ b/1_19_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_19_R2.java
@@ -8,10 +8,7 @@ import net.minecraft.network.protocol.game.PacketPlayOutOpenWindow;
 import net.minecraft.server.level.EntityPlayer;
 import net.minecraft.world.IInventory;
 import net.minecraft.world.entity.player.EntityHuman;
-import net.minecraft.world.inventory.Container;
-import net.minecraft.world.inventory.ContainerAccess;
-import net.minecraft.world.inventory.ContainerAnvil;
-import net.minecraft.world.inventory.Containers;
+import net.minecraft.world.inventory.*;
 import org.bukkit.craftbukkit.v1_19_R2.CraftWorld;
 import org.bukkit.craftbukkit.v1_19_R2.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_19_R2.event.CraftEventFactory;
@@ -103,8 +100,17 @@ public final class Wrapper1_19_R2 implements VersionWrapper {
 
         @Override
         public void l() {
-            super.l();
+            // If the output is empty copy the left input into the output
+            Slot output = this.b(2);
+            if (!output.f()) {
+                output.e(this.b(0).e().o());
+            }
+
             this.w.a(0);
+
+            // Sync to the client
+            this.b();
+            this.d();
         }
 
         @Override

--- a/1_19_R3/pom.xml
+++ b/1_19_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R3</artifactId>

--- a/1_19_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_19_R3.java
+++ b/1_19_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_19_R3.java
@@ -8,10 +8,7 @@ import net.minecraft.network.protocol.game.PacketPlayOutOpenWindow;
 import net.minecraft.server.level.EntityPlayer;
 import net.minecraft.world.IInventory;
 import net.minecraft.world.entity.player.EntityHuman;
-import net.minecraft.world.inventory.Container;
-import net.minecraft.world.inventory.ContainerAccess;
-import net.minecraft.world.inventory.ContainerAnvil;
-import net.minecraft.world.inventory.Containers;
+import net.minecraft.world.inventory.*;
 import org.bukkit.craftbukkit.v1_19_R3.CraftWorld;
 import org.bukkit.craftbukkit.v1_19_R3.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_19_R3.event.CraftEventFactory;
@@ -103,8 +100,17 @@ public final class Wrapper1_19_R3 implements VersionWrapper {
 
         @Override
         public void m() {
-            super.m();
+            // If the output is empty copy the left input into the output
+            Slot output = this.b(2);
+            if (!output.f()) {
+                output.e(this.b(0).e().o());
+            }
+
             this.w.a(0);
+
+            // Sync to the client
+            this.b();
+            this.d();
         }
 
         @Override

--- a/1_20_R1/pom.xml
+++ b/1_20_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_20_R1</artifactId>

--- a/1_20_R1/src/main/java/net.wesjd.anvilgui.version/Wrapper1_20_R1.java
+++ b/1_20_R1/src/main/java/net.wesjd.anvilgui.version/Wrapper1_20_R1.java
@@ -8,10 +8,7 @@ import net.minecraft.network.protocol.game.PacketPlayOutOpenWindow;
 import net.minecraft.server.level.EntityPlayer;
 import net.minecraft.world.IInventory;
 import net.minecraft.world.entity.player.EntityHuman;
-import net.minecraft.world.inventory.Container;
-import net.minecraft.world.inventory.ContainerAccess;
-import net.minecraft.world.inventory.ContainerAnvil;
-import net.minecraft.world.inventory.Containers;
+import net.minecraft.world.inventory.*;
 import org.bukkit.craftbukkit.v1_20_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_20_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_20_R1.event.CraftEventFactory;
@@ -103,8 +100,17 @@ public final class Wrapper1_20_R1 implements VersionWrapper {
 
         @Override
         public void m() {
-            super.m();
+            // If the output is empty copy the left input into the output
+            Slot output = this.b(2);
+            if (!output.f()) {
+                output.e(this.b(0).e().p());
+            }
+
             this.w.a(0);
+
+            // Sync to the client
+            this.b();
+            this.d();
         }
 
         @Override

--- a/1_7_R4/pom.xml
+++ b/1_7_R4/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_7_R4</artifactId>

--- a/1_7_R4/src/main/java/net/wesjd/anvilgui/version/Wrapper1_7_R4.java
+++ b/1_7_R4/src/main/java/net/wesjd/anvilgui/version/Wrapper1_7_R4.java
@@ -126,6 +126,20 @@ public class Wrapper1_7_R4 implements VersionWrapper {
         }
 
         @Override
+        public void e() {
+            // If the output is empty copy the left input into the output
+            Slot output = this.getSlot(2);
+            if (!output.hasItem()) {
+                output.set(this.getSlot(0).getItem().cloneItemStack());
+            }
+
+            this.a = 0;
+
+            // Sync to the client
+            this.b();
+        }
+
+        @Override
         public boolean a(final EntityHuman human) {
             return true;
         }

--- a/1_8_R1/pom.xml
+++ b/1_8_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R1</artifactId>

--- a/1_8_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R1.java
+++ b/1_8_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R1.java
@@ -128,6 +128,20 @@ public class Wrapper1_8_R1 implements VersionWrapper {
         }
 
         @Override
+        public void e() {
+            // If the output is empty copy the left input into the output
+            Slot output = this.getSlot(2);
+            if (!output.hasItem()) {
+                output.set(this.getSlot(0).getItem().cloneItemStack());
+            }
+
+            this.a = 0;
+
+            // Sync to the client
+            this.b();
+        }
+
+        @Override
         public boolean a(EntityHuman human) {
             return true;
         }

--- a/1_8_R2/pom.xml
+++ b/1_8_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R2</artifactId>

--- a/1_8_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R2.java
+++ b/1_8_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R2.java
@@ -128,6 +128,20 @@ public class Wrapper1_8_R2 implements VersionWrapper {
         }
 
         @Override
+        public void e() {
+            // If the output is empty copy the left input into the output
+            Slot output = this.getSlot(2);
+            if (!output.hasItem()) {
+                output.set(this.getSlot(0).getItem().cloneItemStack());
+            }
+
+            this.a = 0;
+
+            // Sync to the client
+            this.b();
+        }
+
+        @Override
         public boolean a(EntityHuman human) {
             return true;
         }

--- a/1_8_R3/pom.xml
+++ b/1_8_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R3</artifactId>

--- a/1_8_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R3.java
+++ b/1_8_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R3.java
@@ -128,6 +128,20 @@ public class Wrapper1_8_R3 implements VersionWrapper {
         }
 
         @Override
+        public void e() {
+            // If the output is empty copy the left input into the output
+            Slot output = this.getSlot(2);
+            if (!output.hasItem()) {
+                output.set(this.getSlot(0).getItem().cloneItemStack());
+            }
+
+            this.a = 0;
+
+            // Sync to the client
+            this.b();
+        }
+
+        @Override
         public boolean a(EntityHuman human) {
             return true;
         }

--- a/1_9_R1/pom.xml
+++ b/1_9_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_9_R1</artifactId>

--- a/1_9_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R1.java
+++ b/1_9_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R1.java
@@ -128,6 +128,20 @@ public class Wrapper1_9_R1 implements VersionWrapper {
         }
 
         @Override
+        public void e() {
+            // If the output is empty copy the left input into the output
+            Slot output = this.getSlot(2);
+            if (!output.hasItem()) {
+                output.set(this.getSlot(0).getItem().cloneItemStack());
+            }
+
+            this.a = 0;
+
+            // Sync to the client
+            this.b();
+        }
+
+        @Override
         public boolean a(EntityHuman entityhuman) {
             return true;
         }

--- a/1_9_R2/pom.xml
+++ b/1_9_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_9_R2</artifactId>

--- a/1_9_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R2.java
+++ b/1_9_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R2.java
@@ -128,6 +128,20 @@ public class Wrapper1_9_R2 implements VersionWrapper {
         }
 
         @Override
+        public void e() {
+            // If the output is empty copy the left input into the output
+            Slot output = this.getSlot(2);
+            if (!output.hasItem()) {
+                output.set(this.getSlot(0).getItem().cloneItemStack());
+            }
+
+            this.a = 0;
+
+            // Sync to the client
+            this.b();
+        }
+
+        @Override
         public boolean a(EntityHuman entityhuman) {
             return true;
         }

--- a/abstraction/pom.xml
+++ b/abstraction/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-abstraction</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.wesjd</groupId>
     <artifactId>anvilgui-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
These changes overwrite every implementation of createResult with a custom one that:
- copies the left input item into the output only if the output does not already have a custom item
- sets the level cost to 0 as usual
- syncs the inventory with the client (which is normally done by the super call)

I noticed that Minecraft 1.7 - 1.11 do not overwrite createResult at all to set the level cost to zero, no clue if that is actually needed to function (I cannot launch Minecraft 1.8 to test because it uses OpenGL improperly), but I added them aswell for good measure.

Also seems to work when the input slots are interactable.

Fixes #237
![Screenshot_20230701_214319](https://github.com/WesJD/AnvilGUI/assets/21055143/c64beadf-dfdf-43c1-a181-dd64f5d7473c)
