### PR TITLE
Fix NullPointerException when attempting to allow for arbitrary input and output items

### DIFF
--- a/1_10_R1/pom.xml
+++ b/1_10_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_10_R1</artifactId>

--- a/1_10_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_10_R1.java
+++ b/1_10_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_10_R1.java
@@ -130,7 +130,11 @@ public class Wrapper1_10_R1 implements VersionWrapper {
             // If the output is empty copy the left input into the output
             Slot output = this.getSlot(2);
             if (!output.hasItem()) {
-                output.set(this.getSlot(0).getItem().cloneItemStack());
+                Slot input = this.getSlot(0);
+
+                if (input.hasItem()) {
+                    output.set(input.getItem().cloneItemStack());
+                }
             }
 
             this.a = 0;

--- a/1_11_R1/pom.xml
+++ b/1_11_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_11_R1</artifactId>

--- a/1_11_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_11_R1.java
+++ b/1_11_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_11_R1.java
@@ -130,7 +130,11 @@ public class Wrapper1_11_R1 implements VersionWrapper {
             // If the output is empty copy the left input into the output
             Slot output = this.getSlot(2);
             if (!output.hasItem()) {
-                output.set(this.getSlot(0).getItem().cloneItemStack());
+                Slot input = this.getSlot(0);
+
+                if (input.hasItem()) {
+                    output.set(input.getItem().cloneItemStack());
+                }
             }
 
             this.a = 0;

--- a/1_12_R1/pom.xml
+++ b/1_12_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_12_R1</artifactId>

--- a/1_12_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_12_R1.java
+++ b/1_12_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_12_R1.java
@@ -131,7 +131,11 @@ public class Wrapper1_12_R1 implements VersionWrapper {
             // If the output is empty copy the left input into the output
             Slot output = this.getSlot(2);
             if (!output.hasItem()) {
-                output.set(this.getSlot(0).getItem().cloneItemStack());
+                Slot input = this.getSlot(0);
+
+                if (input.hasItem()) {
+                    output.set(input.getItem().cloneItemStack());
+                }
             }
 
             this.levelCost = 0;

--- a/1_13_R1/pom.xml
+++ b/1_13_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_13_R1</artifactId>

--- a/1_13_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R1.java
+++ b/1_13_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R1.java
@@ -131,7 +131,11 @@ public class Wrapper1_13_R1 implements VersionWrapper {
             // If the output is empty copy the left input into the output
             Slot output = this.getSlot(2);
             if (!output.hasItem()) {
-                output.set(this.getSlot(0).getItem().cloneItemStack());
+                Slot input = this.getSlot(0);
+
+                if (input.hasItem()) {
+                    output.set(input.getItem().cloneItemStack());
+                }
             }
 
             this.levelCost = 0;

--- a/1_13_R2/pom.xml
+++ b/1_13_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_13_R2</artifactId>

--- a/1_13_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R2.java
+++ b/1_13_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R2.java
@@ -131,7 +131,11 @@ public class Wrapper1_13_R2 implements VersionWrapper {
             // If the output is empty copy the left input into the output
             Slot output = this.getSlot(2);
             if (!output.hasItem()) {
-                output.set(this.getSlot(0).getItem().cloneItemStack());
+                Slot input = this.getSlot(0);
+
+                if (input.hasItem()) {
+                    output.set(input.getItem().cloneItemStack());
+                }
             }
 
             this.levelCost = 0;

--- a/1_14_4_R1/pom.xml
+++ b/1_14_4_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_14_4_R1</artifactId>

--- a/1_14_4_R1/src/main/java/net/wesjd/anvilgui/version/special/AnvilContainer1_14_4_R1.java
+++ b/1_14_4_R1/src/main/java/net/wesjd/anvilgui/version/special/AnvilContainer1_14_4_R1.java
@@ -24,7 +24,11 @@ public class AnvilContainer1_14_4_R1 extends ContainerAnvil implements VersionWr
         // If the output is empty copy the left input into the output
         Slot output = this.getSlot(2);
         if (!output.hasItem()) {
-            output.set(this.getSlot(0).getItem().cloneItemStack());
+            Slot input = this.getSlot(0);
+
+            if (input.hasItem()) {
+                output.set(input.getItem().cloneItemStack());
+            }
         }
 
         this.levelCost.set(0);

--- a/1_14_R1/pom.xml
+++ b/1_14_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_14_R1</artifactId>

--- a/1_14_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_14_R1.java
+++ b/1_14_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_14_R1.java
@@ -140,7 +140,11 @@ public class Wrapper1_14_R1 implements VersionWrapper {
             // If the output is empty copy the left input into the output
             Slot output = this.getSlot(2);
             if (!output.hasItem()) {
-                output.set(this.getSlot(0).getItem().cloneItemStack());
+                Slot input = this.getSlot(0);
+
+                if (input.hasItem()) {
+                    output.set(input.getItem().cloneItemStack());
+                }
             }
 
             this.levelCost.a(0);

--- a/1_15_R1/pom.xml
+++ b/1_15_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_15_R1</artifactId>

--- a/1_15_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_15_R1.java
+++ b/1_15_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_15_R1.java
@@ -127,7 +127,11 @@ public class Wrapper1_15_R1 implements VersionWrapper {
             // If the output is empty copy the left input into the output
             Slot output = this.getSlot(2);
             if (!output.hasItem()) {
-                output.set(this.getSlot(0).getItem().cloneItemStack());
+                Slot input = this.getSlot(0);
+
+                if (input.hasItem()) {
+                    output.set(input.getItem().cloneItemStack());
+                }
             }
 
             this.levelCost.set(0);

--- a/1_16_R1/pom.xml
+++ b/1_16_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R1</artifactId>

--- a/1_16_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R1.java
+++ b/1_16_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R1.java
@@ -127,7 +127,11 @@ public class Wrapper1_16_R1 implements VersionWrapper {
             // If the output is empty copy the left input into the output
             Slot output = this.getSlot(2);
             if (!output.hasItem()) {
-                output.set(this.getSlot(0).getItem().cloneItemStack());
+                Slot input = this.getSlot(0);
+
+                if (input.hasItem()) {
+                    output.set(input.getItem().cloneItemStack());
+                }
             }
 
             this.levelCost.set(0);

--- a/1_16_R2/pom.xml
+++ b/1_16_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R2</artifactId>

--- a/1_16_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R2.java
+++ b/1_16_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R2.java
@@ -127,7 +127,11 @@ public class Wrapper1_16_R2 implements VersionWrapper {
             // If the output is empty copy the left input into the output
             Slot output = this.getSlot(2);
             if (!output.hasItem()) {
-                output.set(this.getSlot(0).getItem().cloneItemStack());
+                Slot input = this.getSlot(0);
+
+                if (input.hasItem()) {
+                    output.set(input.getItem().cloneItemStack());
+                }
             }
 
             this.levelCost.set(0);

--- a/1_16_R3/pom.xml
+++ b/1_16_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R3</artifactId>

--- a/1_16_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R3.java
+++ b/1_16_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R3.java
@@ -127,7 +127,11 @@ public class Wrapper1_16_R3 implements VersionWrapper {
             // If the output is empty copy the left input into the output
             Slot output = this.getSlot(2);
             if (!output.hasItem()) {
-                output.set(this.getSlot(0).getItem().cloneItemStack());
+                Slot input = this.getSlot(0);
+
+                if (input.hasItem()) {
+                    output.set(input.getItem().cloneItemStack());
+                }
             }
 
             this.levelCost.set(0);

--- a/1_17_1_R1/pom.xml
+++ b/1_17_1_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_17_1_R1</artifactId>

--- a/1_17_1_R1/src/main/java/net/wesjd/anvilgui/version/special/AnvilContainer1_17_1_R1.java
+++ b/1_17_1_R1/src/main/java/net/wesjd/anvilgui/version/special/AnvilContainer1_17_1_R1.java
@@ -30,7 +30,11 @@ public class AnvilContainer1_17_1_R1 extends ContainerAnvil implements VersionWr
         // If the output is empty copy the left input into the output
         Slot output = this.getSlot(2);
         if (!output.hasItem()) {
-            output.set(this.getSlot(0).getItem().cloneItemStack());
+            Slot input = this.getSlot(0);
+
+            if (input.hasItem()) {
+                output.set(input.getItem().cloneItemStack());
+            }
         }
 
         this.w.set(0);

--- a/1_17_R1/pom.xml
+++ b/1_17_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_17_R1</artifactId>

--- a/1_17_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_17_R1.java
+++ b/1_17_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_17_R1.java
@@ -144,7 +144,11 @@ public class Wrapper1_17_R1 implements VersionWrapper {
             // If the output is empty copy the left input into the output
             Slot output = this.getSlot(2);
             if (!output.hasItem()) {
-                output.set(this.getSlot(0).getItem().cloneItemStack());
+                Slot input = this.getSlot(0);
+
+                if (input.hasItem()) {
+                    output.set(input.getItem().cloneItemStack());
+                }
             }
 
             this.w.set(0);

--- a/1_18_R1/pom.xml
+++ b/1_18_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_18_R1</artifactId>

--- a/1_18_R2/pom.xml
+++ b/1_18_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_18_R2</artifactId>

--- a/1_19_1_R1/pom.xml
+++ b/1_19_1_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_1_R1</artifactId>

--- a/1_19_R1/pom.xml
+++ b/1_19_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R1</artifactId>

--- a/1_19_R2/pom.xml
+++ b/1_19_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R2</artifactId>

--- a/1_19_R3/pom.xml
+++ b/1_19_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R3</artifactId>

--- a/1_20_R1/pom.xml
+++ b/1_20_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_20_R1</artifactId>

--- a/1_20_R2/pom.xml
+++ b/1_20_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_20_R2</artifactId>

--- a/1_20_R3/pom.xml
+++ b/1_20_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_20_R3</artifactId>

--- a/1_7_R4/pom.xml
+++ b/1_7_R4/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_7_R4</artifactId>

--- a/1_7_R4/src/main/java/net/wesjd/anvilgui/version/Wrapper1_7_R4.java
+++ b/1_7_R4/src/main/java/net/wesjd/anvilgui/version/Wrapper1_7_R4.java
@@ -128,7 +128,11 @@ public class Wrapper1_7_R4 implements VersionWrapper {
             // If the output is empty copy the left input into the output
             Slot output = this.getSlot(2);
             if (!output.hasItem()) {
-                output.set(this.getSlot(0).getItem().cloneItemStack());
+                Slot input = this.getSlot(0);
+
+                if (input.hasItem()) {
+                    output.set(input.getItem().cloneItemStack());
+                }
             }
 
             this.a = 0;

--- a/1_8_R1/pom.xml
+++ b/1_8_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R1</artifactId>

--- a/1_8_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R1.java
+++ b/1_8_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R1.java
@@ -130,7 +130,11 @@ public class Wrapper1_8_R1 implements VersionWrapper {
             // If the output is empty copy the left input into the output
             Slot output = this.getSlot(2);
             if (!output.hasItem()) {
-                output.set(this.getSlot(0).getItem().cloneItemStack());
+                Slot input = this.getSlot(0);
+
+                if (input.hasItem()) {
+                    output.set(input.getItem().cloneItemStack());
+                }
             }
 
             this.a = 0;

--- a/1_8_R2/pom.xml
+++ b/1_8_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R2</artifactId>

--- a/1_8_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R2.java
+++ b/1_8_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R2.java
@@ -130,7 +130,11 @@ public class Wrapper1_8_R2 implements VersionWrapper {
             // If the output is empty copy the left input into the output
             Slot output = this.getSlot(2);
             if (!output.hasItem()) {
-                output.set(this.getSlot(0).getItem().cloneItemStack());
+                Slot input = this.getSlot(0);
+
+                if (input.hasItem()) {
+                    output.set(input.getItem().cloneItemStack());
+                }
             }
 
             this.a = 0;

--- a/1_8_R3/pom.xml
+++ b/1_8_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R3</artifactId>

--- a/1_8_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R3.java
+++ b/1_8_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R3.java
@@ -130,7 +130,11 @@ public class Wrapper1_8_R3 implements VersionWrapper {
             // If the output is empty copy the left input into the output
             Slot output = this.getSlot(2);
             if (!output.hasItem()) {
-                output.set(this.getSlot(0).getItem().cloneItemStack());
+                Slot input = this.getSlot(0);
+
+                if (input.hasItem()) {
+                    output.set(input.getItem().cloneItemStack());
+                }
             }
 
             this.a = 0;

--- a/1_9_R1/pom.xml
+++ b/1_9_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_9_R1</artifactId>

--- a/1_9_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R1.java
+++ b/1_9_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R1.java
@@ -130,7 +130,11 @@ public class Wrapper1_9_R1 implements VersionWrapper {
             // If the output is empty copy the left input into the output
             Slot output = this.getSlot(2);
             if (!output.hasItem()) {
-                output.set(this.getSlot(0).getItem().cloneItemStack());
+                Slot input = this.getSlot(0);
+
+                if (input.hasItem()) {
+                    output.set(input.getItem().cloneItemStack());
+                }
             }
 
             this.a = 0;

--- a/1_9_R2/pom.xml
+++ b/1_9_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_9_R2</artifactId>

--- a/1_9_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R2.java
+++ b/1_9_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R2.java
@@ -130,7 +130,11 @@ public class Wrapper1_9_R2 implements VersionWrapper {
             // If the output is empty copy the left input into the output
             Slot output = this.getSlot(2);
             if (!output.hasItem()) {
-                output.set(this.getSlot(0).getItem().cloneItemStack());
+                Slot input = this.getSlot(0);
+
+                if (input.hasItem()) {
+                    output.set(input.getItem().cloneItemStack());
+                }
             }
 
             this.a = 0;

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ AnvilGUI requires the usage of Maven or a Maven compatible build system.
 <dependency>
     <groupId>net.wesjd</groupId>
     <artifactId>anvilgui</artifactId>
-    <version>1.9.2-SNAPSHOT</version>
+    <version>1.9.3-SNAPSHOT</version>
 </dependency>
 
 <repository>

--- a/abstraction/pom.xml
+++ b/abstraction/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-abstraction</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.2-SNAPSHOT</version>
+        <version>1.9.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.wesjd</groupId>
     <artifactId>anvilgui-parent</artifactId>
-    <version>1.9.2-SNAPSHOT</version>
+    <version>1.9.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
As seen [here](https://mclo.gs/BOpuvux) on older versions of minecraft, the AnvilGUI will throw an error due to this patch not accounting for itemstacks not existing on specific server versions that require it. This patch simply just goes through all the versions that it may effect (this was only tested on 1_8_R3) and seeks to rectify it.

Once this patch is made, the problem is resolved and I can open the AnvilGUIs on 1.8 again, the library's version was bumped to accommodate this.