### PR TITLE
Removed compile dependency

### DIFF
--- a/1_20_R2/pom.xml
+++ b/1_20_R2/pom.xml
@@ -25,12 +25,6 @@
             <version>${project.parent.version}</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
-            <version>1.20.2-R0.1-SNAPSHOT</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/1_20_R3/pom.xml
+++ b/1_20_R3/pom.xml
@@ -25,12 +25,6 @@
             <version>${project.parent.version}</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
-            <version>1.20.3-R0.1-SNAPSHOT</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
I addressed a redundant dependency declaration for 1.20 R2 and R3.

This change does not introduce any functional alterations to the project. It simply streamlines the POM file by removing redundant declarations.

I've tested it without the compile dependencies and it still works