### PR TITLE
Add support for 1.20.5 and 1.20.6

### DIFF
--- a/1_10_R1/pom.xml
+++ b/1_10_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_10_R1</artifactId>

--- a/1_10_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_10_R1.java
+++ b/1_10_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_10_R1.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import net.minecraft.server.v1_10_R1.*;
 import org.bukkit.craftbukkit.v1_10_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_10_R1.event.CraftEventFactory;

--- a/1_11_R1/pom.xml
+++ b/1_11_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_11_R1</artifactId>

--- a/1_11_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_11_R1.java
+++ b/1_11_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_11_R1.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import net.minecraft.server.v1_11_R1.*;
 import org.bukkit.craftbukkit.v1_11_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_11_R1.event.CraftEventFactory;

--- a/1_12_R1/pom.xml
+++ b/1_12_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_12_R1</artifactId>

--- a/1_12_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_12_R1.java
+++ b/1_12_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_12_R1.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import net.minecraft.server.v1_12_R1.*;
 import org.bukkit.craftbukkit.v1_12_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_12_R1.event.CraftEventFactory;

--- a/1_13_R1/pom.xml
+++ b/1_13_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_13_R1</artifactId>

--- a/1_13_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R1.java
+++ b/1_13_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R1.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import net.minecraft.server.v1_13_R1.*;
 import org.bukkit.craftbukkit.v1_13_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_13_R1.event.CraftEventFactory;

--- a/1_13_R2/pom.xml
+++ b/1_13_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_13_R2</artifactId>

--- a/1_13_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R2.java
+++ b/1_13_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R2.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import net.minecraft.server.v1_13_R2.*;
 import org.bukkit.craftbukkit.v1_13_R2.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_13_R2.event.CraftEventFactory;

--- a/1_14_4_R1/pom.xml
+++ b/1_14_4_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_14_4_R1</artifactId>

--- a/1_14_4_R1/src/main/java/net/wesjd/anvilgui/version/special/AnvilContainer1_14_4_R1.java
+++ b/1_14_4_R1/src/main/java/net/wesjd/anvilgui/version/special/AnvilContainer1_14_4_R1.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version.special;
 
-
 import net.minecraft.server.v1_14_R1.*;
 import net.wesjd.anvilgui.version.VersionWrapper;
 import org.bukkit.craftbukkit.v1_14_R1.CraftWorld;

--- a/1_14_R1/pom.xml
+++ b/1_14_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_14_R1</artifactId>

--- a/1_14_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_14_R1.java
+++ b/1_14_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_14_R1.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import net.minecraft.server.v1_14_R1.*;
 import net.wesjd.anvilgui.version.special.AnvilContainer1_14_4_R1;
 import org.bukkit.Bukkit;

--- a/1_15_R1/pom.xml
+++ b/1_15_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_15_R1</artifactId>

--- a/1_15_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_15_R1.java
+++ b/1_15_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_15_R1.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import net.minecraft.server.v1_15_R1.*;
 import org.bukkit.craftbukkit.v1_15_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftPlayer;

--- a/1_16_R1/pom.xml
+++ b/1_16_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R1</artifactId>

--- a/1_16_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R1.java
+++ b/1_16_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R1.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import net.minecraft.server.v1_16_R1.*;
 import org.bukkit.craftbukkit.v1_16_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftPlayer;

--- a/1_16_R2/pom.xml
+++ b/1_16_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R2</artifactId>

--- a/1_16_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R2.java
+++ b/1_16_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R2.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import net.minecraft.server.v1_16_R2.*;
 import org.bukkit.craftbukkit.v1_16_R2.CraftWorld;
 import org.bukkit.craftbukkit.v1_16_R2.entity.CraftPlayer;

--- a/1_16_R3/pom.xml
+++ b/1_16_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R3</artifactId>

--- a/1_16_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R3.java
+++ b/1_16_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R3.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import net.minecraft.server.v1_16_R3.*;
 import org.bukkit.craftbukkit.v1_16_R3.CraftWorld;
 import org.bukkit.craftbukkit.v1_16_R3.entity.CraftPlayer;

--- a/1_17_1_R1/pom.xml
+++ b/1_17_1_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_17_1_R1</artifactId>

--- a/1_17_1_R1/src/main/java/net/wesjd/anvilgui/version/special/AnvilContainer1_17_1_R1.java
+++ b/1_17_1_R1/src/main/java/net/wesjd/anvilgui/version/special/AnvilContainer1_17_1_R1.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version.special;
 
-
 import net.minecraft.core.BlockPosition;
 import net.minecraft.network.chat.ChatComponentText;
 import net.minecraft.network.chat.IChatBaseComponent;

--- a/1_17_R1/pom.xml
+++ b/1_17_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_17_R1</artifactId>

--- a/1_17_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_17_R1.java
+++ b/1_17_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_17_R1.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import net.minecraft.core.BlockPosition;
 import net.minecraft.network.chat.ChatComponentText;
 import net.minecraft.network.chat.IChatBaseComponent;

--- a/1_18_R1/pom.xml
+++ b/1_18_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_18_R1</artifactId>

--- a/1_18_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_18_R1.java
+++ b/1_18_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_18_R1.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import net.minecraft.core.BlockPosition;
 import net.minecraft.network.chat.ChatComponentText;
 import net.minecraft.network.chat.IChatBaseComponent;

--- a/1_18_R2/pom.xml
+++ b/1_18_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_18_R2</artifactId>

--- a/1_18_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_18_R2.java
+++ b/1_18_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_18_R2.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import net.minecraft.core.BlockPosition;
 import net.minecraft.network.chat.ChatComponentText;
 import net.minecraft.network.chat.IChatBaseComponent;

--- a/1_19_1_R1/pom.xml
+++ b/1_19_1_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_1_R1</artifactId>

--- a/1_19_1_R1/src/main/java/net/wesjd/anvilgui/version/special/AnvilContainer1_19_1_R1.java
+++ b/1_19_1_R1/src/main/java/net/wesjd/anvilgui/version/special/AnvilContainer1_19_1_R1.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version.special;
 
-
 import net.minecraft.core.BlockPosition;
 import net.minecraft.network.chat.IChatBaseComponent;
 import net.minecraft.world.IInventory;

--- a/1_19_R1/pom.xml
+++ b/1_19_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R1</artifactId>

--- a/1_19_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_19_R1.java
+++ b/1_19_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_19_R1.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import net.minecraft.core.BlockPosition;
 import net.minecraft.network.chat.IChatBaseComponent;
 import net.minecraft.network.protocol.game.PacketPlayOutCloseWindow;

--- a/1_19_R2/pom.xml
+++ b/1_19_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R2</artifactId>

--- a/1_19_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_19_R2.java
+++ b/1_19_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_19_R2.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import net.minecraft.core.BlockPosition;
 import net.minecraft.network.chat.IChatBaseComponent;
 import net.minecraft.network.protocol.game.PacketPlayOutCloseWindow;

--- a/1_19_R3/pom.xml
+++ b/1_19_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R3</artifactId>

--- a/1_19_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_19_R3.java
+++ b/1_19_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_19_R3.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import net.minecraft.core.BlockPosition;
 import net.minecraft.network.chat.IChatBaseComponent;
 import net.minecraft.network.protocol.game.PacketPlayOutCloseWindow;

--- a/1_20_R1/pom.xml
+++ b/1_20_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_20_R1</artifactId>

--- a/1_20_R1/src/main/java/net.wesjd.anvilgui.version/Wrapper1_20_R1.java
+++ b/1_20_R1/src/main/java/net.wesjd.anvilgui.version/Wrapper1_20_R1.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import net.minecraft.core.BlockPosition;
 import net.minecraft.network.chat.IChatBaseComponent;
 import net.minecraft.network.protocol.game.PacketPlayOutCloseWindow;

--- a/1_20_R2/pom.xml
+++ b/1_20_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_20_R2</artifactId>

--- a/1_20_R2/src/main/java/net.wesjd.anvilgui.version/Wrapper1_20_R2.java
+++ b/1_20_R2/src/main/java/net.wesjd.anvilgui.version/Wrapper1_20_R2.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import net.minecraft.core.BlockPosition;
 import net.minecraft.network.chat.IChatBaseComponent;
 import net.minecraft.network.protocol.game.PacketPlayOutCloseWindow;

--- a/1_20_R3/pom.xml
+++ b/1_20_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_20_R3</artifactId>

--- a/1_20_R3/src/main/java/net.wesjd.anvilgui.version/Wrapper1_20_R3.java
+++ b/1_20_R3/src/main/java/net.wesjd.anvilgui.version/Wrapper1_20_R3.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import net.minecraft.core.BlockPosition;
 import net.minecraft.network.chat.IChatBaseComponent;
 import net.minecraft.network.protocol.game.PacketPlayOutCloseWindow;

--- a/1_20_R4/pom.xml
+++ b/1_20_R4/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.wesjd</groupId>
+        <artifactId>anvilgui-parent</artifactId>
+        <version>1.9.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>anvilgui-1_20_R4</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>1.20.5-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.wesjd</groupId>
+            <artifactId>anvilgui-abstraction</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/1_20_R4/pom.xml
+++ b/1_20_R4/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_20_R4</artifactId>

--- a/1_20_R4/pom.xml
+++ b/1_20_R4/pom.xml
@@ -34,8 +34,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/1_20_R4/src/main/java/net.wesjd.anvilgui.version/Wrapper1_20_R4.java
+++ b/1_20_R4/src/main/java/net.wesjd.anvilgui.version/Wrapper1_20_R4.java
@@ -1,0 +1,146 @@
+package net.wesjd.anvilgui.version;
+
+import net.minecraft.core.BlockPosition;
+import net.minecraft.core.IRegistryCustom;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.network.chat.IChatBaseComponent;
+import net.minecraft.network.protocol.game.PacketPlayOutCloseWindow;
+import net.minecraft.network.protocol.game.PacketPlayOutOpenWindow;
+import net.minecraft.server.level.EntityPlayer;
+import net.minecraft.world.IInventory;
+import net.minecraft.world.entity.player.EntityHuman;
+import net.minecraft.world.inventory.*;
+import org.bukkit.craftbukkit.v1_20_R4.CraftWorld;
+import org.bukkit.craftbukkit.v1_20_R4.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_20_R4.event.CraftEventFactory;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+
+public final class Wrapper1_20_R4 implements VersionWrapper {
+    private int getRealNextContainerId(Player player) {
+        return toNMS(player).nextContainerCounter();
+    }
+
+    /**
+     * Turns a {@link Player} into an NMS one
+     *
+     * @param player The player to be converted
+     * @return the NMS EntityPlayer
+     */
+    private EntityPlayer toNMS(Player player) {
+        return ((CraftPlayer) player).getHandle();
+    }
+
+    @Override
+    public int getNextContainerId(Player player, AnvilContainerWrapper container) {
+        return ((AnvilContainer) container).getContainerId();
+    }
+
+    @Override
+    public void handleInventoryCloseEvent(Player player) {
+        CraftEventFactory.handleInventoryCloseEvent(toNMS(player));
+        toNMS(player).s(); // s -> doCloseContainer
+    }
+
+    @Override
+    public void sendPacketOpenWindow(Player player, int containerId, Object inventoryTitle) {
+        toNMS(player).c.b(new PacketPlayOutOpenWindow(containerId, Containers.i, (IChatBaseComponent) inventoryTitle));
+    }
+
+    @Override
+    public void sendPacketCloseWindow(Player player, int containerId) {
+        toNMS(player).c.b(new PacketPlayOutCloseWindow(containerId));
+    }
+
+    @Override
+    public void setActiveContainerDefault(Player player) {
+        toNMS(player).cb = toNMS(player).ca; // cb -> containerMenu, ca -> inventoryMenu
+    }
+
+    @Override
+    public void setActiveContainer(Player player, AnvilContainerWrapper container) {
+        toNMS(player).cb = (Container) container;
+    }
+
+    @Override
+    public void setActiveContainerId(AnvilContainerWrapper container, int containerId) {}
+
+    @Override
+    public void addActiveContainerSlotListener(AnvilContainerWrapper container, Player player) {
+        toNMS(player).a((Container) container);
+    }
+
+    @Override
+    public AnvilContainerWrapper newContainerAnvil(Player player, Object title) {
+        return new AnvilContainer(player, getRealNextContainerId(player), (IChatBaseComponent) title);
+    }
+
+    @Override
+    public Object literalChatComponent(String content) {
+        return IChatBaseComponent.b(content); // IChatBaseComponent.b -> Component.literal
+    }
+
+    @Override
+    public Object jsonChatComponent(String json) {
+        return IChatBaseComponent.ChatSerializer.a(json, IRegistryCustom.b);
+    }
+
+    private static class AnvilContainer extends ContainerAnvil implements AnvilContainerWrapper {
+        public AnvilContainer(Player player, int containerId, IChatBaseComponent guiTitle) {
+            super(
+                    containerId,
+                    ((CraftPlayer) player).getHandle().gc(),
+                    ContainerAccess.a(((CraftWorld) player.getWorld()).getHandle(), new BlockPosition(0, 0, 0)));
+            this.checkReachable = false;
+            setTitle(guiTitle);
+        }
+
+        @Override
+        public void m() {
+            // If the output is empty copy the left input into the output
+            Slot output = this.b(2); // b -> getSlot
+            if (!output.h()) { // h -> hasItem
+                output.f(this.b(0).g().s()); // f -> set, g -> getItem, s -> copy
+            }
+
+            this.w.a(0); // w -> cost, a -> set
+
+            // Sync to the client
+            this.b(); // b -> sendAllDataToRemote
+            this.d(); // d -> broadcastChanges
+        }
+
+        @Override
+        public void b(EntityHuman player) {}
+
+        @Override
+        protected void a(EntityHuman player, IInventory container) {}
+
+        public int getContainerId() {
+            return this.j;
+        }
+
+        @Override
+        public String getRenameText() {
+            return this.v;
+        }
+
+        @Override
+        public void setRenameText(String text) {
+            // If an item is present in the left input slot change its hover name to the literal text.
+            Slot inputLeft = b(0);
+            if (inputLeft.h()) {
+                inputLeft
+                        .g()
+                        .b(
+                                DataComponents.g,
+                                IChatBaseComponent.b(text)); // DataComponents.g -> DataComponents.CUSTOM_NAME
+            }
+        }
+
+        @Override
+        public Inventory getBukkitInventory() {
+            return getBukkitView().getTopInventory();
+        }
+    }
+}

--- a/1_7_R4/pom.xml
+++ b/1_7_R4/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_7_R4</artifactId>

--- a/1_7_R4/src/main/java/net/wesjd/anvilgui/version/Wrapper1_7_R4.java
+++ b/1_7_R4/src/main/java/net/wesjd/anvilgui/version/Wrapper1_7_R4.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import net.minecraft.server.v1_7_R4.*;
 import org.bukkit.craftbukkit.v1_7_R4.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_7_R4.event.CraftEventFactory;

--- a/1_8_R1/pom.xml
+++ b/1_8_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R1</artifactId>

--- a/1_8_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R1.java
+++ b/1_8_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R1.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import net.minecraft.server.v1_8_R1.*;
 import org.bukkit.craftbukkit.v1_8_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_8_R1.event.CraftEventFactory;

--- a/1_8_R2/pom.xml
+++ b/1_8_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R2</artifactId>

--- a/1_8_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R2.java
+++ b/1_8_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R2.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import net.minecraft.server.v1_8_R2.*;
 import org.bukkit.craftbukkit.v1_8_R2.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_8_R2.event.CraftEventFactory;

--- a/1_8_R3/pom.xml
+++ b/1_8_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R3</artifactId>

--- a/1_8_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R3.java
+++ b/1_8_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R3.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import net.minecraft.server.v1_8_R3.*;
 import org.bukkit.craftbukkit.v1_8_R3.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_8_R3.event.CraftEventFactory;

--- a/1_9_R1/pom.xml
+++ b/1_9_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_9_R1</artifactId>

--- a/1_9_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R1.java
+++ b/1_9_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R1.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import net.minecraft.server.v1_9_R1.*;
 import org.bukkit.craftbukkit.v1_9_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_9_R1.event.CraftEventFactory;

--- a/1_9_R2/pom.xml
+++ b/1_9_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_9_R2</artifactId>

--- a/1_9_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R2.java
+++ b/1_9_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R2.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import net.minecraft.server.v1_9_R2.*;
 import org.bukkit.craftbukkit.v1_9_R2.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_9_R2.event.CraftEventFactory;

--- a/abstraction/pom.xml
+++ b/abstraction/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-abstraction</artifactId>

--- a/abstraction/src/main/java/net/wesjd/anvilgui/version/VersionWrapper.java
+++ b/abstraction/src/main/java/net/wesjd/anvilgui/version/VersionWrapper.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -193,6 +193,12 @@
             <version>${project.parent.version}</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>net.wesjd</groupId>
+            <artifactId>anvilgui-1_20_R4</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui</artifactId>

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui;
 
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;

--- a/api/src/main/java/net/wesjd/anvilgui/version/VersionMatcher.java
+++ b/api/src/main/java/net/wesjd/anvilgui/version/VersionMatcher.java
@@ -1,6 +1,5 @@
 package net.wesjd.anvilgui.version;
 
-
 import org.bukkit.Bukkit;
 
 /**
@@ -18,22 +17,36 @@ public class VersionMatcher {
      * @throws IllegalStateException If the version wrapper failed to be instantiated or is unable to be found
      */
     public VersionWrapper match() {
-        final String serverVersion = Bukkit.getServer()
-                .getClass()
-                .getPackage()
-                .getName()
-                .split("\\.")[3]
-                .substring(1);
+
+        String craftBukkitPackage = Bukkit.getServer().getClass().getPackage().getName();
+
+        String rVersion;
+        if (!craftBukkitPackage.contains(".v")) { // cb package not relocated (i.e. paper 1.20.5+)
+            // separating major and minor versions, example: 1.20.4-R0.1-SNAPSHOT -> major = 20, minor = 4
+            final String[] versionNumbers =
+                    Bukkit.getBukkitVersion().split("-")[0].split("\\.");
+            int major = Integer.parseInt(versionNumbers[1]);
+            int minor = Integer.parseInt(versionNumbers[2]);
+
+            if (major == 20 && minor >= 5) {
+                rVersion = "1_20_R4";
+            } else {
+                throw new IllegalStateException(
+                        "AnvilGUI does not support bukkit server version \"" + Bukkit.getBukkitVersion() + "\"");
+            }
+
+        } else {
+            rVersion = craftBukkitPackage.split("\\.")[3].substring(1);
+        }
+
         try {
-            return (VersionWrapper) Class.forName(getClass().getPackage().getName() + ".Wrapper" + serverVersion)
+            return (VersionWrapper) Class.forName(getClass().getPackage().getName() + ".Wrapper" + rVersion)
                     .getDeclaredConstructor()
                     .newInstance();
         } catch (ClassNotFoundException exception) {
-            throw new IllegalStateException(
-                    "AnvilGUI does not support server version \"" + serverVersion + "\"", exception);
+            throw new IllegalStateException("AnvilGUI does not support server version \"" + rVersion + "\"", exception);
         } catch (ReflectiveOperationException exception) {
-            throw new IllegalStateException(
-                    "Failed to instantiate version wrapper for version " + serverVersion, exception);
+            throw new IllegalStateException("Failed to instantiate version wrapper for version " + rVersion, exception);
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
-                <version>2.22.8</version>
+                <version>2.43.0</version>
                 <inherited>false</inherited> <!-- Only need to run once for the whole project -->
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.wesjd</groupId>
     <artifactId>anvilgui-parent</artifactId>
-    <version>1.9.3-SNAPSHOT</version>
+    <version>1.9.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <module>1_20_R1</module>
         <module>1_20_R2</module>
         <module>1_20_R3</module>
+        <module>1_20_R4</module>
     </modules>
 
     <repositories>


### PR DESCRIPTION
This adds support for both paper and spigot 1.20.5/1.20.6.

Tested on:
- Spigot 1.20.5
- Paper 1.20.5
- Paper 1.20.6
- Spigot 1.8.8

It needs JDK 21 to compile. I've also updated the Spotless version, since the older Spotless version threw errors on jdk 21.