### PR TITLE
Fix VersionMatcher compatibility with other 1.20.x versions

### DIFF
--- a/1_10_R1/pom.xml
+++ b/1_10_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_10_R1</artifactId>

--- a/1_11_R1/pom.xml
+++ b/1_11_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_11_R1</artifactId>

--- a/1_12_R1/pom.xml
+++ b/1_12_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_12_R1</artifactId>

--- a/1_13_R1/pom.xml
+++ b/1_13_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_13_R1</artifactId>

--- a/1_13_R2/pom.xml
+++ b/1_13_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_13_R2</artifactId>

--- a/1_14_4_R1/pom.xml
+++ b/1_14_4_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_14_4_R1</artifactId>

--- a/1_14_R1/pom.xml
+++ b/1_14_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_14_R1</artifactId>

--- a/1_15_R1/pom.xml
+++ b/1_15_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_15_R1</artifactId>

--- a/1_16_R1/pom.xml
+++ b/1_16_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R1</artifactId>

--- a/1_16_R2/pom.xml
+++ b/1_16_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R2</artifactId>

--- a/1_16_R3/pom.xml
+++ b/1_16_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R3</artifactId>

--- a/1_17_1_R1/pom.xml
+++ b/1_17_1_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_17_1_R1</artifactId>

--- a/1_17_R1/pom.xml
+++ b/1_17_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_17_R1</artifactId>

--- a/1_18_R1/pom.xml
+++ b/1_18_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_18_R1</artifactId>

--- a/1_18_R2/pom.xml
+++ b/1_18_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_18_R2</artifactId>

--- a/1_19_1_R1/pom.xml
+++ b/1_19_1_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_1_R1</artifactId>

--- a/1_19_R1/pom.xml
+++ b/1_19_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R1</artifactId>

--- a/1_19_R2/pom.xml
+++ b/1_19_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R2</artifactId>

--- a/1_19_R3/pom.xml
+++ b/1_19_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R3</artifactId>

--- a/1_20_R1/pom.xml
+++ b/1_20_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_20_R1</artifactId>

--- a/1_20_R2/pom.xml
+++ b/1_20_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_20_R2</artifactId>

--- a/1_20_R3/pom.xml
+++ b/1_20_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_20_R3</artifactId>

--- a/1_20_R4/pom.xml
+++ b/1_20_R4/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_20_R4</artifactId>

--- a/1_21_R1/pom.xml
+++ b/1_21_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_21_R1</artifactId>

--- a/1_7_R4/pom.xml
+++ b/1_7_R4/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_7_R4</artifactId>

--- a/1_8_R1/pom.xml
+++ b/1_8_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R1</artifactId>

--- a/1_8_R2/pom.xml
+++ b/1_8_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R2</artifactId>

--- a/1_8_R3/pom.xml
+++ b/1_8_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R3</artifactId>

--- a/1_9_R1/pom.xml
+++ b/1_9_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_9_R1</artifactId>

--- a/1_9_R2/pom.xml
+++ b/1_9_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_9_R2</artifactId>

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ AnvilGUI requires the usage of Maven or a Maven compatible build system.
 <dependency>
     <groupId>net.wesjd</groupId>
     <artifactId>anvilgui</artifactId>
-    <version>1.9.5-SNAPSHOT</version>
+    <version>1.9.6-SNAPSHOT</version>
 </dependency>
 
 <repository>

--- a/abstraction/pom.xml
+++ b/abstraction/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-abstraction</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.5-SNAPSHOT</version>
+        <version>1.9.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui</artifactId>

--- a/api/src/main/java/net/wesjd/anvilgui/version/VersionMatcher.java
+++ b/api/src/main/java/net/wesjd/anvilgui/version/VersionMatcher.java
@@ -1,5 +1,7 @@
 package net.wesjd.anvilgui.version;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.bukkit.Bukkit;
 
 /**
@@ -9,6 +11,18 @@ import org.bukkit.Bukkit;
  * @since 1.2.1
  */
 public class VersionMatcher {
+    /** Maps a Minecraft version string to the corresponding revision string */
+    private static final Map<String, String> VERSION_TO_REVISION = new HashMap<String, String>() {
+        {
+            this.put("1.20", "1_20_R1");
+            this.put("1.20.1", "1_20_R1");
+            this.put("1.20.2", "1_20_R2");
+            this.put("1.20.3", "1_20_R3");
+            this.put("1.20.4", "1_20_R3");
+            this.put("1.20.5", "1_20_R4");
+            this.put("1.20.6", "1_20_R4");
+        }
+    };
 
     /**
      * Matches the server version to it's {@link VersionWrapper}
@@ -17,26 +31,17 @@ public class VersionMatcher {
      * @throws IllegalStateException If the version wrapper failed to be instantiated or is unable to be found
      */
     public VersionWrapper match() {
-
         String craftBukkitPackage = Bukkit.getServer().getClass().getPackage().getName();
 
         String rVersion;
         if (!craftBukkitPackage.contains(".v")) { // cb package not relocated (i.e. paper 1.20.5+)
             // separating major and minor versions, example: 1.20.4-R0.1-SNAPSHOT -> major = 20, minor = 4
-            final String[] versionNumbers =
-                    Bukkit.getBukkitVersion().split("-")[0].split("\\.");
-            int major = Integer.parseInt(versionNumbers[1]);
-            int minor = Integer.parseInt(versionNumbers[2]);
-
-            if (major == 20 && minor >= 5) {
-                rVersion = "1_20_R4";
-            } else if (major == 21) {
-                rVersion = "1_21_R1";
-            } else {
+            final String version = Bukkit.getBukkitVersion().split("-")[0];
+            if (!VERSION_TO_REVISION.containsKey(version)) {
                 throw new IllegalStateException(
                         "AnvilGUI does not support bukkit server version \"" + Bukkit.getBukkitVersion() + "\"");
             }
-
+            rVersion = VERSION_TO_REVISION.get(version);
         } else {
             rVersion = craftBukkitPackage.split("\\.")[3].substring(1);
         }

--- a/api/src/main/java/net/wesjd/anvilgui/version/VersionMatcher.java
+++ b/api/src/main/java/net/wesjd/anvilgui/version/VersionMatcher.java
@@ -21,6 +21,7 @@ public class VersionMatcher {
             this.put("1.20.4", "1_20_R3");
             this.put("1.20.5", "1_20_R4");
             this.put("1.20.6", "1_20_R4");
+            this.put("1.21", "1_21_R1");
         }
     };
 

--- a/api/src/main/java/net/wesjd/anvilgui/version/VersionMatcher.java
+++ b/api/src/main/java/net/wesjd/anvilgui/version/VersionMatcher.java
@@ -24,6 +24,8 @@ public class VersionMatcher {
             this.put("1.21", "1_21_R1");
         }
     };
+    /* This needs to be updated to reflect the newest available version wrapper */
+    private static final String FALLBACK_REVISION = "1_21_R1";
 
     /**
      * Matches the server version to it's {@link VersionWrapper}
@@ -36,13 +38,8 @@ public class VersionMatcher {
 
         String rVersion;
         if (!craftBukkitPackage.contains(".v")) { // cb package not relocated (i.e. paper 1.20.5+)
-            // separating major and minor versions, example: 1.20.4-R0.1-SNAPSHOT -> major = 20, minor = 4
             final String version = Bukkit.getBukkitVersion().split("-")[0];
-            if (!VERSION_TO_REVISION.containsKey(version)) {
-                throw new IllegalStateException(
-                        "AnvilGUI does not support bukkit server version \"" + Bukkit.getBukkitVersion() + "\"");
-            }
-            rVersion = VERSION_TO_REVISION.get(version);
+            rVersion = VERSION_TO_REVISION.getOrDefault(version, FALLBACK_REVISION);
         } else {
             rVersion = craftBukkitPackage.split("\\.")[3].substring(1);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.wesjd</groupId>
     <artifactId>anvilgui-parent</artifactId>
-    <version>1.9.5-SNAPSHOT</version>
+    <version>1.9.6-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
Fixes to the implementation from #326, as I originally suggested in #294.

This fixes compatibility with relocated server JARs before 1.20.5 and provides a safer and shorter implementation than what we have currently. Also works with 1.20.6.

Furthermore, we don't even need all of this extra checking technically. The `Bukkit.getBukkitVersion()` function has existed since 2011, and we could just rely on that 100% of the time if we want to create a massive map or we rename all of the version wrappers to their respective Minecraft version name. But I'll leave that open for now.