### PR TITLE
Send experience packets to support Bedrock via Geyser

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,0 @@
---add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/1_10_R1/pom.xml
+++ b/1_10_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_10_R1</artifactId>

--- a/1_10_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_10_R1.java
+++ b/1_10_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_10_R1.java
@@ -54,6 +54,14 @@ public class Wrapper1_10_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).playerConnection.sendPacket(new PacketPlayOutExperience(0f, 0, experienceLevel));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void setActiveContainerDefault(Player player) {
         toNMS(player).activeContainer = toNMS(player).defaultContainer;
     }

--- a/1_11_R1/pom.xml
+++ b/1_11_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_11_R1</artifactId>

--- a/1_11_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_11_R1.java
+++ b/1_11_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_11_R1.java
@@ -54,6 +54,14 @@ public class Wrapper1_11_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).playerConnection.sendPacket(new PacketPlayOutExperience(0f, 0, experienceLevel));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void setActiveContainerDefault(Player player) {
         toNMS(player).activeContainer = toNMS(player).defaultContainer;
     }

--- a/1_12_R1/pom.xml
+++ b/1_12_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_12_R1</artifactId>

--- a/1_12_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_12_R1.java
+++ b/1_12_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_12_R1.java
@@ -54,6 +54,14 @@ public class Wrapper1_12_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).playerConnection.sendPacket(new PacketPlayOutExperience(0f, 0, experienceLevel));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void setActiveContainerDefault(Player player) {
         toNMS(player).activeContainer = toNMS(player).defaultContainer;
     }

--- a/1_13_R1/pom.xml
+++ b/1_13_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_13_R1</artifactId>

--- a/1_13_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R1.java
+++ b/1_13_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R1.java
@@ -54,6 +54,14 @@ public class Wrapper1_13_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).playerConnection.sendPacket(new PacketPlayOutExperience(0f, 0, experienceLevel));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void setActiveContainerDefault(Player player) {
         toNMS(player).activeContainer = toNMS(player).defaultContainer;
     }

--- a/1_13_R2/pom.xml
+++ b/1_13_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_13_R2</artifactId>

--- a/1_13_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R2.java
+++ b/1_13_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_13_R2.java
@@ -54,6 +54,14 @@ public class Wrapper1_13_R2 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).playerConnection.sendPacket(new PacketPlayOutExperience(0f, 0, experienceLevel));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void setActiveContainerDefault(Player player) {
         toNMS(player).activeContainer = toNMS(player).defaultContainer;
     }

--- a/1_14_4_R1/pom.xml
+++ b/1_14_4_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_14_4_R1</artifactId>

--- a/1_14_R1/pom.xml
+++ b/1_14_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_14_R1</artifactId>

--- a/1_14_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_14_R1.java
+++ b/1_14_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_14_R1.java
@@ -60,6 +60,14 @@ public class Wrapper1_14_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).playerConnection.sendPacket(new PacketPlayOutExperience(0f, 0, experienceLevel));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void setActiveContainerDefault(Player player) {
         toNMS(player).activeContainer = toNMS(player).defaultContainer;
     }

--- a/1_15_R1/pom.xml
+++ b/1_15_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_15_R1</artifactId>

--- a/1_15_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_15_R1.java
+++ b/1_15_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_15_R1.java
@@ -51,6 +51,14 @@ public class Wrapper1_15_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).playerConnection.sendPacket(new PacketPlayOutExperience(0f, 0, experienceLevel));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void setActiveContainerDefault(Player player) {
         toNMS(player).activeContainer = toNMS(player).defaultContainer;
     }

--- a/1_16_R1/pom.xml
+++ b/1_16_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R1</artifactId>

--- a/1_16_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R1.java
+++ b/1_16_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R1.java
@@ -51,6 +51,14 @@ public class Wrapper1_16_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).playerConnection.sendPacket(new PacketPlayOutExperience(0f, 0, experienceLevel));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void setActiveContainerDefault(Player player) {
         toNMS(player).activeContainer = toNMS(player).defaultContainer;
     }

--- a/1_16_R2/pom.xml
+++ b/1_16_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R2</artifactId>

--- a/1_16_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R2.java
+++ b/1_16_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R2.java
@@ -51,6 +51,14 @@ public class Wrapper1_16_R2 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).playerConnection.sendPacket(new PacketPlayOutExperience(0f, 0, experienceLevel));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void setActiveContainerDefault(Player player) {
         toNMS(player).activeContainer = toNMS(player).defaultContainer;
     }

--- a/1_16_R3/pom.xml
+++ b/1_16_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R3</artifactId>

--- a/1_16_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R3.java
+++ b/1_16_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_16_R3.java
@@ -51,6 +51,14 @@ public class Wrapper1_16_R3 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).playerConnection.sendPacket(new PacketPlayOutExperience(0f, 0, experienceLevel));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void setActiveContainerDefault(Player player) {
         toNMS(player).activeContainer = toNMS(player).defaultContainer;
     }

--- a/1_17_1_R1/pom.xml
+++ b/1_17_1_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_17_1_R1</artifactId>

--- a/1_17_R1/pom.xml
+++ b/1_17_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_17_R1</artifactId>

--- a/1_17_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_17_R1.java
+++ b/1_17_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_17_R1.java
@@ -4,6 +4,7 @@ import net.minecraft.core.BlockPosition;
 import net.minecraft.network.chat.ChatComponentText;
 import net.minecraft.network.chat.IChatBaseComponent;
 import net.minecraft.network.protocol.game.PacketPlayOutCloseWindow;
+import net.minecraft.network.protocol.game.PacketPlayOutExperience;
 import net.minecraft.network.protocol.game.PacketPlayOutOpenWindow;
 import net.minecraft.server.level.EntityPlayer;
 import net.minecraft.world.IInventory;
@@ -60,6 +61,14 @@ public class Wrapper1_17_R1 implements VersionWrapper {
     @Override
     public void sendPacketCloseWindow(Player player, int containerId) {
         toNMS(player).b.sendPacket(new PacketPlayOutCloseWindow(containerId));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).b.sendPacket(new PacketPlayOutExperience(0f, 0, experienceLevel));
     }
 
     /**

--- a/1_18_R1/pom.xml
+++ b/1_18_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_18_R1</artifactId>

--- a/1_18_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_18_R1.java
+++ b/1_18_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_18_R1.java
@@ -4,6 +4,7 @@ import net.minecraft.core.BlockPosition;
 import net.minecraft.network.chat.ChatComponentText;
 import net.minecraft.network.chat.IChatBaseComponent;
 import net.minecraft.network.protocol.game.PacketPlayOutCloseWindow;
+import net.minecraft.network.protocol.game.PacketPlayOutExperience;
 import net.minecraft.network.protocol.game.PacketPlayOutOpenWindow;
 import net.minecraft.server.level.EntityPlayer;
 import net.minecraft.world.IInventory;
@@ -49,6 +50,11 @@ public final class Wrapper1_18_R1 implements VersionWrapper {
     @Override
     public void sendPacketCloseWindow(Player player, int containerId) {
         toNMS(player).b.a(new PacketPlayOutCloseWindow(containerId));
+    }
+
+    @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).b.a(new PacketPlayOutExperience(0f, 0, experienceLevel));
     }
 
     @Override

--- a/1_18_R2/pom.xml
+++ b/1_18_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_18_R2</artifactId>

--- a/1_18_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_18_R2.java
+++ b/1_18_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_18_R2.java
@@ -4,6 +4,7 @@ import net.minecraft.core.BlockPosition;
 import net.minecraft.network.chat.ChatComponentText;
 import net.minecraft.network.chat.IChatBaseComponent;
 import net.minecraft.network.protocol.game.PacketPlayOutCloseWindow;
+import net.minecraft.network.protocol.game.PacketPlayOutExperience;
 import net.minecraft.network.protocol.game.PacketPlayOutOpenWindow;
 import net.minecraft.server.level.EntityPlayer;
 import net.minecraft.world.IInventory;
@@ -49,6 +50,11 @@ public final class Wrapper1_18_R2 implements VersionWrapper {
     @Override
     public void sendPacketCloseWindow(Player player, int containerId) {
         toNMS(player).b.a(new PacketPlayOutCloseWindow(containerId));
+    }
+
+    @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).b.a(new PacketPlayOutExperience(0f, 0, experienceLevel));
     }
 
     @Override

--- a/1_19_1_R1/pom.xml
+++ b/1_19_1_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_1_R1</artifactId>

--- a/1_19_R1/pom.xml
+++ b/1_19_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R1</artifactId>

--- a/1_19_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_19_R1.java
+++ b/1_19_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_19_R1.java
@@ -3,6 +3,7 @@ package net.wesjd.anvilgui.version;
 import net.minecraft.core.BlockPosition;
 import net.minecraft.network.chat.IChatBaseComponent;
 import net.minecraft.network.protocol.game.PacketPlayOutCloseWindow;
+import net.minecraft.network.protocol.game.PacketPlayOutExperience;
 import net.minecraft.network.protocol.game.PacketPlayOutOpenWindow;
 import net.minecraft.server.level.EntityPlayer;
 import net.minecraft.world.IInventory;
@@ -56,6 +57,11 @@ public final class Wrapper1_19_R1 implements VersionWrapper {
     @Override
     public void sendPacketCloseWindow(Player player, int containerId) {
         toNMS(player).b.a(new PacketPlayOutCloseWindow(containerId));
+    }
+
+    @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).b.a(new PacketPlayOutExperience(0f, 0, experienceLevel));
     }
 
     @Override

--- a/1_19_R2/pom.xml
+++ b/1_19_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R2</artifactId>

--- a/1_19_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_19_R2.java
+++ b/1_19_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_19_R2.java
@@ -3,6 +3,7 @@ package net.wesjd.anvilgui.version;
 import net.minecraft.core.BlockPosition;
 import net.minecraft.network.chat.IChatBaseComponent;
 import net.minecraft.network.protocol.game.PacketPlayOutCloseWindow;
+import net.minecraft.network.protocol.game.PacketPlayOutExperience;
 import net.minecraft.network.protocol.game.PacketPlayOutOpenWindow;
 import net.minecraft.server.level.EntityPlayer;
 import net.minecraft.world.IInventory;
@@ -48,6 +49,11 @@ public final class Wrapper1_19_R2 implements VersionWrapper {
     @Override
     public void sendPacketCloseWindow(Player player, int containerId) {
         toNMS(player).b.a(new PacketPlayOutCloseWindow(containerId));
+    }
+
+    @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).b.a(new PacketPlayOutExperience(0f, 0, experienceLevel));
     }
 
     @Override

--- a/1_19_R3/pom.xml
+++ b/1_19_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R3</artifactId>

--- a/1_19_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_19_R3.java
+++ b/1_19_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_19_R3.java
@@ -3,6 +3,7 @@ package net.wesjd.anvilgui.version;
 import net.minecraft.core.BlockPosition;
 import net.minecraft.network.chat.IChatBaseComponent;
 import net.minecraft.network.protocol.game.PacketPlayOutCloseWindow;
+import net.minecraft.network.protocol.game.PacketPlayOutExperience;
 import net.minecraft.network.protocol.game.PacketPlayOutOpenWindow;
 import net.minecraft.server.level.EntityPlayer;
 import net.minecraft.world.IInventory;
@@ -48,6 +49,11 @@ public final class Wrapper1_19_R3 implements VersionWrapper {
     @Override
     public void sendPacketCloseWindow(Player player, int containerId) {
         toNMS(player).b.a(new PacketPlayOutCloseWindow(containerId));
+    }
+
+    @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).b.a(new PacketPlayOutExperience(0f, 0, experienceLevel));
     }
 
     @Override

--- a/1_20_R1/pom.xml
+++ b/1_20_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_20_R1</artifactId>

--- a/1_20_R1/src/main/java/net.wesjd.anvilgui.version/Wrapper1_20_R1.java
+++ b/1_20_R1/src/main/java/net.wesjd.anvilgui.version/Wrapper1_20_R1.java
@@ -3,6 +3,7 @@ package net.wesjd.anvilgui.version;
 import net.minecraft.core.BlockPosition;
 import net.minecraft.network.chat.IChatBaseComponent;
 import net.minecraft.network.protocol.game.PacketPlayOutCloseWindow;
+import net.minecraft.network.protocol.game.PacketPlayOutExperience;
 import net.minecraft.network.protocol.game.PacketPlayOutOpenWindow;
 import net.minecraft.server.level.EntityPlayer;
 import net.minecraft.world.IInventory;
@@ -48,6 +49,11 @@ public final class Wrapper1_20_R1 implements VersionWrapper {
     @Override
     public void sendPacketCloseWindow(Player player, int containerId) {
         toNMS(player).c.a(new PacketPlayOutCloseWindow(containerId));
+    }
+
+    @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).c.a(new PacketPlayOutExperience(0f, 0, experienceLevel));
     }
 
     @Override

--- a/1_20_R2/pom.xml
+++ b/1_20_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_20_R2</artifactId>

--- a/1_20_R2/src/main/java/net.wesjd.anvilgui.version/Wrapper1_20_R2.java
+++ b/1_20_R2/src/main/java/net.wesjd.anvilgui.version/Wrapper1_20_R2.java
@@ -3,6 +3,7 @@ package net.wesjd.anvilgui.version;
 import net.minecraft.core.BlockPosition;
 import net.minecraft.network.chat.IChatBaseComponent;
 import net.minecraft.network.protocol.game.PacketPlayOutCloseWindow;
+import net.minecraft.network.protocol.game.PacketPlayOutExperience;
 import net.minecraft.network.protocol.game.PacketPlayOutOpenWindow;
 import net.minecraft.server.level.EntityPlayer;
 import net.minecraft.world.IInventory;
@@ -48,6 +49,11 @@ public final class Wrapper1_20_R2 implements VersionWrapper {
     @Override
     public void sendPacketCloseWindow(Player player, int containerId) {
         toNMS(player).c.b(new PacketPlayOutCloseWindow(containerId));
+    }
+
+    @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).c.b(new PacketPlayOutExperience(0f, 0, experienceLevel));
     }
 
     @Override

--- a/1_20_R3/pom.xml
+++ b/1_20_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_20_R3</artifactId>

--- a/1_20_R3/src/main/java/net.wesjd.anvilgui.version/Wrapper1_20_R3.java
+++ b/1_20_R3/src/main/java/net.wesjd.anvilgui.version/Wrapper1_20_R3.java
@@ -3,6 +3,7 @@ package net.wesjd.anvilgui.version;
 import net.minecraft.core.BlockPosition;
 import net.minecraft.network.chat.IChatBaseComponent;
 import net.minecraft.network.protocol.game.PacketPlayOutCloseWindow;
+import net.minecraft.network.protocol.game.PacketPlayOutExperience;
 import net.minecraft.network.protocol.game.PacketPlayOutOpenWindow;
 import net.minecraft.server.level.EntityPlayer;
 import net.minecraft.world.IInventory;
@@ -48,6 +49,11 @@ public final class Wrapper1_20_R3 implements VersionWrapper {
     @Override
     public void sendPacketCloseWindow(Player player, int containerId) {
         toNMS(player).c.b(new PacketPlayOutCloseWindow(containerId));
+    }
+
+    @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).c.b(new PacketPlayOutExperience(0f, 0, experienceLevel));
     }
 
     @Override

--- a/1_20_R4/pom.xml
+++ b/1_20_R4/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_20_R4</artifactId>

--- a/1_20_R4/src/main/java/net.wesjd.anvilgui.version/Wrapper1_20_R4.java
+++ b/1_20_R4/src/main/java/net.wesjd.anvilgui.version/Wrapper1_20_R4.java
@@ -5,6 +5,7 @@ import net.minecraft.core.IRegistryCustom;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.IChatBaseComponent;
 import net.minecraft.network.protocol.game.PacketPlayOutCloseWindow;
+import net.minecraft.network.protocol.game.PacketPlayOutExperience;
 import net.minecraft.network.protocol.game.PacketPlayOutOpenWindow;
 import net.minecraft.server.level.EntityPlayer;
 import net.minecraft.world.IInventory;
@@ -50,6 +51,11 @@ public final class Wrapper1_20_R4 implements VersionWrapper {
     @Override
     public void sendPacketCloseWindow(Player player, int containerId) {
         toNMS(player).c.b(new PacketPlayOutCloseWindow(containerId));
+    }
+
+    @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).c.b(new PacketPlayOutExperience(0f, 0, experienceLevel));
     }
 
     @Override

--- a/1_21_R1/pom.xml
+++ b/1_21_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_21_R1</artifactId>

--- a/1_21_R1/src/main/java/net.wesjd.anvilgui.version/Wrapper1_21_R1.java
+++ b/1_21_R1/src/main/java/net.wesjd.anvilgui.version/Wrapper1_21_R1.java
@@ -5,6 +5,7 @@ import net.minecraft.core.IRegistryCustom;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.IChatBaseComponent;
 import net.minecraft.network.protocol.game.PacketPlayOutCloseWindow;
+import net.minecraft.network.protocol.game.PacketPlayOutExperience;
 import net.minecraft.network.protocol.game.PacketPlayOutOpenWindow;
 import net.minecraft.server.level.EntityPlayer;
 import net.minecraft.world.IInventory;
@@ -50,6 +51,11 @@ public final class Wrapper1_21_R1 implements VersionWrapper {
     @Override
     public void sendPacketCloseWindow(Player player, int containerId) {
         toNMS(player).c.b(new PacketPlayOutCloseWindow(containerId));
+    }
+
+    @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).c.b(new PacketPlayOutExperience(0f, 0, experienceLevel));
     }
 
     @Override

--- a/1_7_R4/pom.xml
+++ b/1_7_R4/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_7_R4</artifactId>

--- a/1_7_R4/src/main/java/net/wesjd/anvilgui/version/Wrapper1_7_R4.java
+++ b/1_7_R4/src/main/java/net/wesjd/anvilgui/version/Wrapper1_7_R4.java
@@ -52,6 +52,14 @@ public class Wrapper1_7_R4 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
+    public void sendPacketExperienceChange(final Player player, final int experienceLevel) {
+        toNMS(player).playerConnection.sendPacket(new PacketPlayOutExperience(0f, 0, experienceLevel));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void setActiveContainerDefault(final Player player) {
         this.toNMS(player).activeContainer = this.toNMS(player).defaultContainer;
     }

--- a/1_8_R1/pom.xml
+++ b/1_8_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R1</artifactId>

--- a/1_8_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R1.java
+++ b/1_8_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R1.java
@@ -54,6 +54,14 @@ public class Wrapper1_8_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).playerConnection.sendPacket(new PacketPlayOutExperience(0f, 0, experienceLevel));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void setActiveContainerDefault(Player player) {
         toNMS(player).activeContainer = toNMS(player).defaultContainer;
     }

--- a/1_8_R2/pom.xml
+++ b/1_8_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R2</artifactId>

--- a/1_8_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R2.java
+++ b/1_8_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R2.java
@@ -54,6 +54,14 @@ public class Wrapper1_8_R2 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).playerConnection.sendPacket(new PacketPlayOutExperience(0f, 0, experienceLevel));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void setActiveContainerDefault(Player player) {
         toNMS(player).activeContainer = toNMS(player).defaultContainer;
     }

--- a/1_8_R3/pom.xml
+++ b/1_8_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R3</artifactId>

--- a/1_8_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R3.java
+++ b/1_8_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_8_R3.java
@@ -54,6 +54,14 @@ public class Wrapper1_8_R3 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).playerConnection.sendPacket(new PacketPlayOutExperience(0f, 0, experienceLevel));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void setActiveContainerDefault(Player player) {
         toNMS(player).activeContainer = toNMS(player).defaultContainer;
     }

--- a/1_9_R1/pom.xml
+++ b/1_9_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_9_R1</artifactId>

--- a/1_9_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R1.java
+++ b/1_9_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R1.java
@@ -54,6 +54,14 @@ public class Wrapper1_9_R1 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).playerConnection.sendPacket(new PacketPlayOutExperience(0f, 0, experienceLevel));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void setActiveContainerDefault(Player player) {
         toNMS(player).activeContainer = toNMS(player).defaultContainer;
     }

--- a/1_9_R2/pom.xml
+++ b/1_9_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_9_R2</artifactId>

--- a/1_9_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R2.java
+++ b/1_9_R2/src/main/java/net/wesjd/anvilgui/version/Wrapper1_9_R2.java
@@ -54,6 +54,14 @@ public class Wrapper1_9_R2 implements VersionWrapper {
      * {@inheritDoc}
      */
     @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).playerConnection.sendPacket(new PacketPlayOutExperience(0f, 0, experienceLevel));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void setActiveContainerDefault(Player player) {
         toNMS(player).activeContainer = toNMS(player).defaultContainer;
     }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ AnvilGUI requires the usage of Maven or a Maven compatible build system.
 <dependency>
     <groupId>net.wesjd</groupId>
     <artifactId>anvilgui</artifactId>
-    <version>1.9.6-SNAPSHOT</version>
+    <version>1.10.0-SNAPSHOT</version>
 </dependency>
 
 <repository>

--- a/README.md
+++ b/README.md
@@ -158,6 +158,13 @@ Useful for situations like password input to play.
 builder.preventClose();
 ```
 
+#### `geyserCompat()`
+This toggles compatibility with Geyser software, specifically being able to use AnvilGUI with 0 experience level on Bedrock.
+Enabled by default.
+```java
+builder.geyserCompat();
+```
+
 #### `text(String)`
 Takes a `String` that contains what the initial text in the renaming field should be set to.
 If `itemLeft` is provided, then the display name is set to the provided text. If no `itemLeft`

--- a/abstraction/pom.xml
+++ b/abstraction/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-abstraction</artifactId>

--- a/abstraction/src/main/java/net/wesjd/anvilgui/version/VersionWrapper.java
+++ b/abstraction/src/main/java/net/wesjd/anvilgui/version/VersionWrapper.java
@@ -37,12 +37,20 @@ public interface VersionWrapper {
     void sendPacketOpenWindow(Player player, int containerId, Object inventoryTitle);
 
     /**
-     * Sends PacketPlayOutCloseWindow to the player with the contaienr id
+     * Sends PacketPlayOutCloseWindow to the player with the container id
      *
      * @param player      The player to send the packet to
      * @param containerId The container id to close
      */
     void sendPacketCloseWindow(Player player, int containerId);
+
+    /**
+     * Sends PacketPlayOutExperience to the player with the experience level
+     *
+     * @param player          The player to send the packet to
+     * @param experienceLevel The experience level to set
+     */
+    void sendPacketExperienceChange(Player player, int experienceLevel);
 
     /**
      * Sets the NMS player's active container to the default one

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.9.6-SNAPSHOT</version>
+        <version>1.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -205,6 +205,12 @@
             <version>${project.parent.version}</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.geysermc.geyser</groupId>
+            <artifactId>api</artifactId>
+            <version>2.4.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -163,45 +163,6 @@ public class AnvilGUI {
     }
 
     /**
-     * Create an AnvilGUI
-     *
-     * @deprecated Use instead {@link AnvilGUI(Plugin, Player, Executor, Object, ItemStack[], boolean, Set, Consumer, boolean, AnvilGUI.ClickHandler)}
-     * @param plugin           A {@link org.bukkit.plugin.java.JavaPlugin} instance
-     * @param player           The {@link Player} to open the inventory for
-     * @param mainThreadExecutor An {@link Executor} that executes on the main server thread
-     * @param titleComponent   What to have the text already set to
-     * @param initialContents  The initial contents of the inventory
-     * @param preventClose     Whether to prevent the inventory from closing
-     * @param closeListener    A {@link Consumer} when the inventory closes
-     * @param concurrentClickHandlerExecution Flag to allow concurrent execution of the click handler
-     * @param clickHandler     A {@link ClickHandler} that is called when the player clicks a slot
-     */
-    @Deprecated
-    private AnvilGUI(
-            Plugin plugin,
-            Player player,
-            Executor mainThreadExecutor,
-            Object titleComponent,
-            ItemStack[] initialContents,
-            boolean preventClose,
-            Set<Integer> interactableSlots,
-            Consumer<StateSnapshot> closeListener,
-            boolean concurrentClickHandlerExecution,
-            ClickHandler clickHandler) {
-        this.plugin = plugin;
-        this.player = player;
-        this.mainThreadExecutor = mainThreadExecutor;
-        this.titleComponent = titleComponent;
-        this.initialContents = initialContents;
-        this.preventClose = preventClose;
-        this.geyserCompatibility = true;
-        this.interactableSlots = Collections.unmodifiableSet(interactableSlots);
-        this.closeListener = closeListener;
-        this.concurrentClickHandlerExecution = concurrentClickHandlerExecution;
-        this.clickHandler = clickHandler;
-    }
-
-    /**
      * Opens the anvil GUI
      */
     private void openInventory() {
@@ -498,10 +459,10 @@ public class AnvilGUI {
         }
 
         /**
-         * Toggles compatibility with Geyser software
+         * Disables compatibility with Geyser software
          */
-        public Builder geyserCompat(boolean enabled) {
-            geyserCompatibility = enabled;
+        public Builder disableGeyserCompat() {
+            geyserCompatibility = false;
             return this;
         }
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,6 +1,0 @@
-# Tell Jitpack to build using Java 21 (defaults to 8)
-before_install:
-  - source "$HOME/.sdkman/bin/sdkman-init.sh"
-  - sdk update
-  - sdk install java 21.0.3-zulu
-  - sdk use java 21.0.3-zulu

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,6 @@
+# Tell Jitpack to build using Java 21 (defaults to 8)
+before_install:
+  - source "$HOME/.sdkman/bin/sdkman-init.sh"
+  - sdk update
+  - sdk install java 21.0.3-zulu
+  - sdk use java 21.0.3-zulu

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.wesjd</groupId>
     <artifactId>anvilgui-parent</artifactId>
-    <version>1.9.6-SNAPSHOT</version>
+    <version>1.10.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,10 @@
             <id>nms-repo</id>
             <url>https://repo.codemc.org/repository/nms/</url>
         </repository>
+        <repository>
+            <id>opencollab-snapshot</id>
+            <url>https://repo.opencollab.dev/main/</url>
+        </repository>
     </repositories>
 
     <build>


### PR DESCRIPTION
Fixes #332 

Bedrock does not allow the result slot to be clicked when the player's experience level is 0. This change sends a packet which sets the Bedrock client's level to 20 (number is trivial) on anvil open, and then again back to the actual value when closed. It adds a `.gesyer-compat(boolean)` to the builder, which is enabled by default. A second constructor has been added to AnvilGUI for backwards compatibility.

In writing this, it occurs to me it may be preferred to have the method be something like `.disableGeyserCompat()` instead, to match `.preventClose()`. Let me know if that's what you'd prefer.

Other changes I made in order to test this:
- Removed jvm.config. As mentioned in #329 it is no longer required with the newer version of Spotless we're on, see https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md#2227---2022-06-10
- ~~Added a jitpack.yml file which allows AnvilGUI to be compiled on the popular [jitpack.io](https://www.jitpack.io/) repository~~