### PR TITLE
Fix InventoryCloseEvent firing twice

### DIFF
--- a/1_20_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_20_R3.java
+++ b/1_20_R3/src/main/java/net/wesjd/anvilgui/version/Wrapper1_20_R3.java
@@ -38,7 +38,7 @@ public final class Wrapper1_20_R3 implements VersionWrapper {
     @Override
     public void handleInventoryCloseEvent(Player player) {
         CraftEventFactory.handleInventoryCloseEvent(toNMS(player));
-        toNMS(player).r(); // r -> doCloseContainer
+        toNMS(player).s(); // s -> doCloseContainer
     }
 
     @Override

--- a/1_21_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_21_R1.java
+++ b/1_21_R1/src/main/java/net/wesjd/anvilgui/version/Wrapper1_21_R1.java
@@ -40,7 +40,7 @@ public final class Wrapper1_21_R1 implements VersionWrapper {
     @Override
     public void handleInventoryCloseEvent(Player player) {
         CraftEventFactory.handleInventoryCloseEvent(toNMS(player));
-        toNMS(player).s(); // s -> doCloseContainer
+        toNMS(player).t(); // t -> doCloseContainer
     }
 
     @Override
@@ -60,7 +60,7 @@ public final class Wrapper1_21_R1 implements VersionWrapper {
 
     @Override
     public void setActiveContainerDefault(Player player) {
-        toNMS(player).cd = toNMS(player).cc; // cb -> containerMenu, ca -> inventoryMenu
+        toNMS(player).cd = toNMS(player).cc; // cd -> containerMenu, cc -> inventoryMenu
     }
 
     @Override


### PR DESCRIPTION
Fixes #339

It looks like the reason for the bug is a mismatch in the mappings for some of the NMS wrappers. Specifically, `closeContainer` was being called instead of `doCloseContainer`, which will lead to the `InventoryCloseEvent` firing an extra time (should be pretty clear if you look at the code in an IDE so you can jump between the relevant methods). The comment makes it pretty clear that `doCloseContainer` is what *should* be called, not `closeContainer` (in fact, if you look at the other wrappers, even all the way back to 1.8, this has always been the case). The mappings are mismatched in the `1_20_R3` wrapper and the `1_21_R1` wrapper, but not the `1_20_R4` wrapper or any other version I could find. For reference, [here is the mapping history](https://mappings.dev/history/d68245377d.html), you can search for "doCloseContainer" to find all the changes.

So basically, before this fix, on specifically Minecraft 1.20.3, 1.20.4 and 1.21, `closeContainer` was called instead of `doCloseContainer`, which caused the close event to be fired twice instead of once.