### PR TITLE
Manually parse legacy color codes to MiniMessage

### DIFF
--- a/1_10_R1/pom.xml
+++ b/1_10_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_10_R1</artifactId>

--- a/1_11_R1/pom.xml
+++ b/1_11_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_11_R1</artifactId>

--- a/1_12_R1/pom.xml
+++ b/1_12_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_12_R1</artifactId>

--- a/1_13_R1/pom.xml
+++ b/1_13_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_13_R1</artifactId>

--- a/1_13_R2/pom.xml
+++ b/1_13_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_13_R2</artifactId>

--- a/1_14_4_R1/pom.xml
+++ b/1_14_4_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_14_4_R1</artifactId>

--- a/1_14_R1/pom.xml
+++ b/1_14_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_14_R1</artifactId>

--- a/1_15_R1/pom.xml
+++ b/1_15_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_15_R1</artifactId>

--- a/1_16_R1/pom.xml
+++ b/1_16_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R1</artifactId>

--- a/1_16_R2/pom.xml
+++ b/1_16_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R2</artifactId>

--- a/1_16_R3/pom.xml
+++ b/1_16_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R3</artifactId>

--- a/1_17_1_R1/pom.xml
+++ b/1_17_1_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_17_1_R1</artifactId>

--- a/1_17_R1/pom.xml
+++ b/1_17_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_17_R1</artifactId>

--- a/1_18_R1/pom.xml
+++ b/1_18_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_18_R1</artifactId>

--- a/1_18_R2/pom.xml
+++ b/1_18_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_18_R2</artifactId>

--- a/1_19_1_R1/pom.xml
+++ b/1_19_1_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_1_R1</artifactId>

--- a/1_19_R1/pom.xml
+++ b/1_19_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R1</artifactId>

--- a/1_19_R2/pom.xml
+++ b/1_19_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R2</artifactId>

--- a/1_19_R3/pom.xml
+++ b/1_19_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R3</artifactId>

--- a/1_20_R1/pom.xml
+++ b/1_20_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_20_R1</artifactId>

--- a/1_20_R2/pom.xml
+++ b/1_20_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_20_R2</artifactId>

--- a/1_20_R3/pom.xml
+++ b/1_20_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_20_R3</artifactId>

--- a/1_20_R4/pom.xml
+++ b/1_20_R4/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_20_R4</artifactId>

--- a/1_21_R1/pom.xml
+++ b/1_21_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_21_R1</artifactId>

--- a/1_21_R2/pom.xml
+++ b/1_21_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_21_R2</artifactId>

--- a/1_21_R3/pom.xml
+++ b/1_21_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_21_R3</artifactId>

--- a/1_7_R4/pom.xml
+++ b/1_7_R4/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_7_R4</artifactId>

--- a/1_8_R1/pom.xml
+++ b/1_8_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R1</artifactId>

--- a/1_8_R2/pom.xml
+++ b/1_8_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R2</artifactId>

--- a/1_8_R3/pom.xml
+++ b/1_8_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R3</artifactId>

--- a/1_9_R1/pom.xml
+++ b/1_9_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_9_R1</artifactId>

--- a/1_9_R2/pom.xml
+++ b/1_9_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_9_R2</artifactId>

--- a/abstraction/pom.xml
+++ b/abstraction/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-abstraction</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.4-SNAPSHOT</version>
+        <version>1.10.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui</artifactId>
@@ -17,6 +17,12 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
             <version>1.8-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.21.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -12,6 +12,8 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.logging.Level;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.wesjd.anvilgui.version.VersionMatcher;
 import net.wesjd.anvilgui.version.VersionWrapper;
@@ -250,6 +252,10 @@ public class AnvilGUI {
      */
     public void setTitle(String literalTitle, boolean preserveRenameText) {
         Validate.notNull(literalTitle, "literalTitle cannot be null");
+        if (VersionMatcher.requiresMini)
+            literalTitle = MiniMessage.miniMessage()
+                    .serialize(LegacyComponentSerializer.legacyAmpersand().deserialize(title.replace('§', '&')));
+
         setTitle(WRAPPER.literalChatComponent(literalTitle), preserveRenameText);
     }
 
@@ -587,6 +593,10 @@ public class AnvilGUI {
          */
         public Builder title(String title) {
             Validate.notNull(title, "title cannot be null");
+            if (VersionMatcher.requiresMini)
+                title = MiniMessage.miniMessage()
+                        .serialize(LegacyComponentSerializer.legacyAmpersand().deserialize(title.replace('§', '&')));
+
             this.titleComponent = WRAPPER.literalChatComponent(title);
             return this;
         }

--- a/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
+++ b/api/src/main/java/net/wesjd/anvilgui/AnvilGUI.java
@@ -254,7 +254,7 @@ public class AnvilGUI {
         Validate.notNull(literalTitle, "literalTitle cannot be null");
         if (VersionMatcher.requiresMini)
             literalTitle = MiniMessage.miniMessage()
-                    .serialize(LegacyComponentSerializer.legacyAmpersand().deserialize(title.replace('§', '&')));
+                    .serialize(LegacyComponentSerializer.legacyAmpersand().deserialize(literalTitle.replace('§', '&')));
 
         setTitle(WRAPPER.literalChatComponent(literalTitle), preserveRenameText);
     }

--- a/api/src/main/java/net/wesjd/anvilgui/version/VersionMatcher.java
+++ b/api/src/main/java/net/wesjd/anvilgui/version/VersionMatcher.java
@@ -31,6 +31,9 @@ public class VersionMatcher {
     /* This needs to be updated to reflect the newest available version wrapper */
     private static final String FALLBACK_REVISION = "1_21_R3";
 
+    // Paper 1.21.4+ removes support for legacy color codes when opening the inventory using packets
+    public static final boolean requiresMini = needsMiniMessage();
+
     /**
      * Matches the server version to it's {@link VersionWrapper}
      *
@@ -57,5 +60,25 @@ public class VersionMatcher {
         } catch (ReflectiveOperationException exception) {
             throw new IllegalStateException("Failed to instantiate version wrapper for version " + rVersion, exception);
         }
+    }
+
+    /**
+     * Checks if the server runs paper 1.21.4+ cause it removes support for legacy color codes in the inventory title
+     * so we parse any legacy color codes to MiniMessage format
+     *
+     * @return true if this server doesn't support legacy color codes, false otherwise
+     */
+    private static boolean needsMiniMessage() {
+        String craftBukkitPackage = Bukkit.getServer().getClass().getPackage().getName();
+        if (!craftBukkitPackage.contains(".v")) { // cb package not relocated (i.e. paper 1.20.5+)
+            try {
+                int version = Integer.parseInt(Bukkit.getBukkitVersion().split("-")[0].replace(".", ""));
+
+                if (version >= 1214) // Check for server version above or equal to 1.21.4
+                    return true;
+            } catch (NumberFormatException e) {} // Invalid version number
+        }
+
+        return false;
     }
 }

--- a/api/src/main/java/net/wesjd/anvilgui/version/VersionMatcher.java
+++ b/api/src/main/java/net/wesjd/anvilgui/version/VersionMatcher.java
@@ -72,11 +72,13 @@ public class VersionMatcher {
         String craftBukkitPackage = Bukkit.getServer().getClass().getPackage().getName();
         if (!craftBukkitPackage.contains(".v")) { // cb package not relocated (i.e. paper 1.20.5+)
             try {
-                int version = Integer.parseInt(Bukkit.getBukkitVersion().split("-")[0].replace(".", ""));
+                int version =
+                        Integer.parseInt(Bukkit.getBukkitVersion().split("-")[0].replace(".", ""));
 
                 if (version >= 1214) // Check for server version above or equal to 1.21.4
-                    return true;
-            } catch (NumberFormatException e) {} // Invalid version number
+                return true;
+            } catch (NumberFormatException e) {
+            } // Invalid version number
         }
 
         return false;

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.wesjd</groupId>
     <artifactId>anvilgui-parent</artifactId>
-    <version>1.10.4-SNAPSHOT</version>
+    <version>1.10.5-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>
@@ -54,6 +54,10 @@
         <repository>
             <id>nms-repo</id>
             <url>https://repo.codemc.org/repository/nms/</url>
+        </repository>
+        <repository>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
         <repository>
             <id>opencollab-snapshot</id>


### PR DESCRIPTION
This version uses the paper's MiniMessage API to Manually parse legacy color codes to MiniMessage format, since paper 1.21.4 doesn't support legacy color codes in Inventory titles sent directly using packets.