### PR TITLE
1.21.6 Quickfix for Spigot

### DIFF
--- a/1_10_R1/pom.xml
+++ b/1_10_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_10_R1</artifactId>

--- a/1_11_R1/pom.xml
+++ b/1_11_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_11_R1</artifactId>

--- a/1_12_R1/pom.xml
+++ b/1_12_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_12_R1</artifactId>

--- a/1_13_R1/pom.xml
+++ b/1_13_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_13_R1</artifactId>

--- a/1_13_R2/pom.xml
+++ b/1_13_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_13_R2</artifactId>

--- a/1_14_4_R1/pom.xml
+++ b/1_14_4_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_14_4_R1</artifactId>

--- a/1_14_R1/pom.xml
+++ b/1_14_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_14_R1</artifactId>

--- a/1_15_R1/pom.xml
+++ b/1_15_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_15_R1</artifactId>

--- a/1_16_R1/pom.xml
+++ b/1_16_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R1</artifactId>

--- a/1_16_R2/pom.xml
+++ b/1_16_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R2</artifactId>

--- a/1_16_R3/pom.xml
+++ b/1_16_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_16_R3</artifactId>

--- a/1_17_1_R1/pom.xml
+++ b/1_17_1_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_17_1_R1</artifactId>

--- a/1_17_R1/pom.xml
+++ b/1_17_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_17_R1</artifactId>

--- a/1_18_R1/pom.xml
+++ b/1_18_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_18_R1</artifactId>

--- a/1_18_R2/pom.xml
+++ b/1_18_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_18_R2</artifactId>

--- a/1_19_R1/pom.xml
+++ b/1_19_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R1</artifactId>

--- a/1_19_R2/pom.xml
+++ b/1_19_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R2</artifactId>

--- a/1_19_R3/pom.xml
+++ b/1_19_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_19_R3</artifactId>

--- a/1_20_R1/pom.xml
+++ b/1_20_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_20_R1</artifactId>

--- a/1_20_R2/pom.xml
+++ b/1_20_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_20_R2</artifactId>

--- a/1_20_R3/pom.xml
+++ b/1_20_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_20_R3</artifactId>

--- a/1_20_R4/pom.xml
+++ b/1_20_R4/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_20_R4</artifactId>

--- a/1_21_R1/pom.xml
+++ b/1_21_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_21_R1</artifactId>

--- a/1_21_R2/pom.xml
+++ b/1_21_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_21_R2</artifactId>

--- a/1_21_R3/pom.xml
+++ b/1_21_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_21_R3</artifactId>

--- a/1_21_R4/pom.xml
+++ b/1_21_R4/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_21_R4</artifactId>

--- a/1_21_R5/pom.xml
+++ b/1_21_R5/pom.xml
@@ -10,13 +10,13 @@
         <version>1.10.6-SNAPSHOT</version>
     </parent>
 
-    <artifactId>anvilgui-1_19_1_R1</artifactId>
+    <artifactId>anvilgui-1_21_R5</artifactId>
 
     <dependencies>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
-            <version>1.19.1-R0.1-SNAPSHOT</version>
+            <version>1.21.6-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -34,8 +34,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/1_21_R5/src/main/java/net/wesjd/anvilgui/version/Wrapper1_21_R5.java
+++ b/1_21_R5/src/main/java/net/wesjd/anvilgui/version/Wrapper1_21_R5.java
@@ -1,0 +1,87 @@
+package net.wesjd.anvilgui.version;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+/**
+ * Delegates to Spigot or Paper wrapper for Minecraft 1.21 R5 depending on runtime environment.
+ */
+public final class Wrapper1_21_R5 implements VersionWrapper {
+
+    private final VersionWrapper delegate;
+
+    public Wrapper1_21_R5() {
+        if (!isPaper()) {
+            this.delegate = new Wrapper1_21_R5_Spigot();
+        } else {
+            throw new IllegalStateException("Wrapper does not support Paper atm");
+        }
+    }
+
+    /**
+     * Detects if the server is Paper by checking for the presence of Mojang-mapped class names.
+     */
+    private boolean isPaper() {
+        return !Bukkit.getServer().getClass().getPackage().getName().contains(".v");
+    }
+
+    @Override
+    public int getNextContainerId(Player player, AnvilContainerWrapper container) {
+        return delegate.getNextContainerId(player, container);
+    }
+
+    @Override
+    public void handleInventoryCloseEvent(Player player) {
+        delegate.handleInventoryCloseEvent(player);
+    }
+
+    @Override
+    public void sendPacketOpenWindow(Player player, int containerId, Object inventoryTitle) {
+        delegate.sendPacketOpenWindow(player, containerId, inventoryTitle);
+    }
+
+    @Override
+    public void sendPacketCloseWindow(Player player, int containerId) {
+        delegate.sendPacketCloseWindow(player, containerId);
+    }
+
+    @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        delegate.sendPacketExperienceChange(player, experienceLevel);
+    }
+
+    @Override
+    public void setActiveContainerDefault(Player player) {
+        delegate.setActiveContainerDefault(player);
+    }
+
+    @Override
+    public void setActiveContainer(Player player, AnvilContainerWrapper container) {
+        delegate.setActiveContainer(player, container);
+    }
+
+    @Override
+    public void setActiveContainerId(AnvilContainerWrapper container, int containerId) {
+        delegate.setActiveContainerId(container, containerId);
+    }
+
+    @Override
+    public void addActiveContainerSlotListener(AnvilContainerWrapper container, Player player) {
+        delegate.addActiveContainerSlotListener(container, player);
+    }
+
+    @Override
+    public AnvilContainerWrapper newContainerAnvil(Player player, Object title) {
+        return delegate.newContainerAnvil(player, title);
+    }
+
+    @Override
+    public Object literalChatComponent(String content) {
+        return delegate.literalChatComponent(content);
+    }
+
+    @Override
+    public Object jsonChatComponent(String json) {
+        return delegate.jsonChatComponent(json);
+    }
+}

--- a/1_21_R5/src/main/java/net/wesjd/anvilgui/version/Wrapper1_21_R5_Spigot.java
+++ b/1_21_R5/src/main/java/net/wesjd/anvilgui/version/Wrapper1_21_R5_Spigot.java
@@ -1,0 +1,138 @@
+package net.wesjd.anvilgui.version;
+
+import net.minecraft.core.BlockPosition;
+import net.minecraft.core.IRegistryCustom;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.network.chat.IChatBaseComponent;
+import net.minecraft.network.protocol.game.PacketPlayOutCloseWindow;
+import net.minecraft.network.protocol.game.PacketPlayOutExperience;
+import net.minecraft.network.protocol.game.PacketPlayOutOpenWindow;
+import net.minecraft.server.level.EntityPlayer;
+import net.minecraft.world.IInventory;
+import net.minecraft.world.entity.player.EntityHuman;
+import net.minecraft.world.inventory.*;
+import org.bukkit.craftbukkit.v1_21_R5.CraftWorld;
+import org.bukkit.craftbukkit.v1_21_R5.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_21_R5.event.CraftEventFactory;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+
+public final class Wrapper1_21_R5_Spigot implements VersionWrapper {
+
+    private EntityPlayer toNMS(Player player) {
+        return ((CraftPlayer) player).getHandle();
+    }
+
+    private int getRealNextContainerId(Player player) {
+        return toNMS(player).nextContainerCounter();
+    }
+
+    @Override
+    public int getNextContainerId(Player player, AnvilContainerWrapper container) {
+        return ((AnvilContainer) container).getContainerId();
+    }
+
+    @Override
+    public void handleInventoryCloseEvent(Player player) {
+        CraftEventFactory.handleInventoryCloseEvent(toNMS(player));
+        toNMS(player).p(); // p -> doCloseContainer
+    }
+
+    @Override
+    public void sendPacketOpenWindow(Player player, int containerId, Object inventoryTitle) {
+        toNMS(player).g.b(new PacketPlayOutOpenWindow(containerId, Containers.i, (IChatBaseComponent) inventoryTitle));
+    }
+
+    @Override
+    public void sendPacketCloseWindow(Player player, int containerId) {
+        toNMS(player).g.b(new PacketPlayOutCloseWindow(containerId));
+    }
+
+    @Override
+    public void sendPacketExperienceChange(Player player, int experienceLevel) {
+        toNMS(player).g.b(new PacketPlayOutExperience(0f, 0, experienceLevel));
+    }
+
+    @Override
+    public void setActiveContainerDefault(Player player) {
+        toNMS(player).cn = toNMS(player).cm;
+    }
+
+    @Override
+    public void setActiveContainer(Player player, AnvilContainerWrapper container) {
+        toNMS(player).cn = (Container) container;
+    }
+
+    @Override
+    public void setActiveContainerId(AnvilContainerWrapper container, int containerId) {}
+
+    @Override
+    public void addActiveContainerSlotListener(AnvilContainerWrapper container, Player player) {
+        toNMS(player).a((Container) container);
+    }
+
+    @Override
+    public AnvilContainerWrapper newContainerAnvil(Player player, Object title) {
+        return new AnvilContainer(player, getRealNextContainerId(player), (IChatBaseComponent) title);
+    }
+
+    @Override
+    public Object literalChatComponent(String content) {
+        return IChatBaseComponent.b(content);
+    }
+
+    @Override
+    public Object jsonChatComponent(String json) {
+        return IChatBaseComponent.a(json, IRegistryCustom.b);
+    }
+
+    private static class AnvilContainer extends ContainerAnvil implements AnvilContainerWrapper {
+        public AnvilContainer(Player player, int containerId, IChatBaseComponent guiTitle) {
+            super(
+                    containerId,
+                    ((CraftPlayer) player).getHandle().gs(),
+                    ContainerAccess.a(((CraftWorld) player.getWorld()).getHandle(), new BlockPosition(0, 0, 0)));
+            this.checkReachable = false;
+            setTitle(guiTitle);
+        }
+
+        @Override
+        public void l() {
+            Slot output = this.b(2);
+            if (!output.h()) {
+                output.f(this.b(0).g().v());
+            }
+            this.y.a(0);
+            this.b();
+            this.d();
+        }
+
+        @Override
+        public void a(EntityHuman player) {}
+
+        @Override
+        protected void a(EntityHuman player, IInventory container) {}
+
+        public int getContainerId() {
+            return this.l;
+        }
+
+        @Override
+        public String getRenameText() {
+            return this.x;
+        }
+
+        @Override
+        public void setRenameText(String text) {
+            Slot inputLeft = b(0);
+            if (inputLeft.h()) {
+                inputLeft.g().b(DataComponents.g, IChatBaseComponent.b(text));
+            }
+        }
+
+        @Override
+        public Inventory getBukkitInventory() {
+            return ((Container) this).getBukkitView().getTopInventory();
+        }
+    }
+}

--- a/1_7_R4/pom.xml
+++ b/1_7_R4/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_7_R4</artifactId>

--- a/1_8_R1/pom.xml
+++ b/1_8_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R1</artifactId>

--- a/1_8_R2/pom.xml
+++ b/1_8_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R2</artifactId>

--- a/1_8_R3/pom.xml
+++ b/1_8_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_8_R3</artifactId>

--- a/1_9_R1/pom.xml
+++ b/1_9_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_9_R1</artifactId>

--- a/1_9_R2/pom.xml
+++ b/1_9_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-1_9_R2</artifactId>

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ AnvilGUI requires the usage of Maven or a Maven compatible build system.
 <dependency>
     <groupId>net.wesjd</groupId>
     <artifactId>anvilgui</artifactId>
-    <version>1.10.5-SNAPSHOT</version>
+    <version>1.10.6-SNAPSHOT</version>
 </dependency>
 
 <repository>

--- a/abstraction/pom.xml
+++ b/abstraction/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui-abstraction</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.wesjd</groupId>
         <artifactId>anvilgui-parent</artifactId>
-        <version>1.10.5-SNAPSHOT</version>
+        <version>1.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>anvilgui</artifactId>
@@ -220,6 +220,12 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui-1_21_R4</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.wesjd</groupId>
+            <artifactId>anvilgui-1_21_R5</artifactId>
             <version>${project.parent.version}</version>
             <scope>compile</scope>
         </dependency>

--- a/api/src/main/java/net/wesjd/anvilgui/version/VersionMatcher.java
+++ b/api/src/main/java/net/wesjd/anvilgui/version/VersionMatcher.java
@@ -27,10 +27,11 @@ public class VersionMatcher {
             this.put("1.21.3", "1_21_R2");
             this.put("1.21.4", "1_21_R3");
             this.put("1.21.5", "1_21_R4");
+            this.put("1.21.6", "1_21_R5");
         }
     };
     /* This needs to be updated to reflect the newest available version wrapper */
-    private static final String FALLBACK_REVISION = "1_21_R4";
+    private static final String FALLBACK_REVISION = "1_21_R5";
 
     /**
      * Matches the server version to it's {@link VersionWrapper}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.wesjd</groupId>
     <artifactId>anvilgui-parent</artifactId>
-    <version>1.10.5-SNAPSHOT</version>
+    <version>1.10.6-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>
@@ -49,6 +49,7 @@
         <module>1_21_R2</module>
         <module>1_21_R3</module>
         <module>1_21_R4</module>
+        <module>1_21_R5</module>
     </modules>
 
     <repositories>


### PR DESCRIPTION
I'm not entirely sure why Paper isn't working — I assume they've moved and renamed some classes.
I attempted to create a working solution using [mappings.dev for 1.21.6](https://mappings.dev/1.21.6/index.html), but I wasn't successful.

Additionally, the first error thrown when loading the solution for v1_21_R4 - after renaming the obfuscated methods - is as follows:

> Caused by: java.lang.ClassNotFoundException: net.minecraft.world.entity.player.EntityHuman
        at net.wesjd.anvilgui.version.Wrapper1_21_R5.<init>(Wrapper1_21_R5.java:**) 
        at net.wesjd.anvilgui.version.VersionMatcher.match(VersionMatcher.java:56) 
        at net.wesjd.anvilgui.AnvilGUI.<clinit>(AnvilGUI.java:43) 
        
-> Basically the Method Wrapper1_21_R5_Spigot#toNMS fails because the returned class's superclass EntityHuman has been moved.