### PR TITLE
Downgrade Java versions from 25 to 21

### DIFF
--- a/26_R1/pom.xml
+++ b/26_R1/pom.xml
@@ -34,8 +34,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>25</source>
-                    <target>25</target>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
This is needed to proper support plugin remapping the lib. E.g. for Paper 1.21.4.

Closes #408.